### PR TITLE
fix: imagePullSecrets indentation

### DIFF
--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -42,7 +42,7 @@ spec:
       {{- if .Values.backstage.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.backstage.image.pullSecrets }}
-          - name: {{ . }}
+        - name: {{ . }}
       {{- end }}
       {{- end }}
       containers:


### PR DESCRIPTION
## Description

Indentation is too wide (2 spaces), so it doesn't render in final output.