### PR TITLE
Fix indentation for serviceAccount labels and annotations

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 dependencies:
   - name: common

--- a/charts/backstage/templates/serviceaccount.yaml
+++ b/charts/backstage/templates/serviceaccount.yaml
@@ -6,13 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: backstage
-      {{- with .Values.serviceAccount.labels }}
-      {{ toYaml . | trim | indent 8 }}
-      {{- end }}
+    {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
   {{- if .Values.serviceAccount.annotations }}
   annotations:
     {{- with .Values.serviceAccount.annotations }}
-    {{ toYaml . | trim | indent 8 }}
+    {{- toYaml . | trim | nindent 4 }}
     {{- end }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}


### PR DESCRIPTION
Fixes indentation issues with labels and annotations in the service account template.

The following values.yaml
```yaml
backstage:
  image:
    registry: repo
    repository: backstage
    tag: master
serviceAccount:
  create: true
  annotations:
    eks.amazonaws.com/role-arn: "ROLE"
    eks.amazonaws.com/sts-regional-endpoints: "true"
  labels:
    nginx.ingress.kubernetes.io/rewrite-target: "/"
    nginx.ingress.kubernetes.io/ssl-redirect: "false"
```

Now returns:

```yaml
---
# Source: backstage/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: 
  namespace: default
  labels:
    app.kubernetes.io/component: backstage
    nginx.ingress.kubernetes.io/rewrite-target: /
    nginx.ingress.kubernetes.io/ssl-redirect: "false"
  annotations:
    eks.amazonaws.com/role-arn: ROLE
    eks.amazonaws.com/sts-regional-endpoints: "true"
automountServiceAccountToken: true
```