### PR TITLE
fix: Ingress annotations format

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 dependencies:
   - name: common

--- a/charts/backstage/templates/ingress.yaml
+++ b/charts/backstage/templates/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
   annotations:
     {{- if .Values.ingress.annotations }}
-    {{ include "common.tplvalues.render" ( dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -65,10 +65,7 @@ ingress:
   className: ""
 
   ## @param ingress.annotations Additional annotations for the Ingress resource
-  annotations: '{
-    "nginx.ingress.kubernetes.io/rewrite-target": "/",
-    "nginx.ingress.kubernetes.io/ssl-redirect": "false"
-  }'
+  annotations: {}
 
   ## @param host Hostname to be used to expose the route to access the backstage application (e.g: backstage.IP.nip.io)
   host: ""


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

Ingress annotations were a string instead of a proper dictionary

## Existing or Associated Issue(s)

<!-- List any related issues. -->
n/a

## Additional Information

If rendered with the default values as:

```sh
helm template --set backstage.image.registry=registry,backstage.image.repository=repo/image,backstage.image.tag=latest,ingress.enabled=true .
```

The ingress was rendered as:

```yaml
...
# Source: backstage/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: release-name-backstage
  namespace: "tumido"
  labels:
    app.kubernetes.io/name: backstage
    helm.sh/chart: backstage-0.5.2
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: backstage
  annotations:

    { "nginx.ingress.kubernetes.io/rewrite-target": "/", "nginx.ingress.kubernetes.io/ssl-redirect": "false" }
...
```

After the change the Ingress template renders:

```yaml
...
# Source: backstage/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: release-name-backstage
  namespace: "tumido"
  labels:
    app.kubernetes.io/name: backstage
    helm.sh/chart: backstage-0.5.3
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: backstage
  annotations:
    nginx.ingress.kubernetes.io/rewrite-target: /
    nginx.ingress.kubernetes.io/ssl-redirect: "false"
```

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
