### PR TITLE
Default to upstream image

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This chart bootstraps a [Backstage](https://backstage.io/docs/deployment/docker)
 - Kubernetes 1.19+
 - Helm 3.2.0+
 - PV provisioner support in the underlying infrastructure
-- [Backstage container image](https://backstage.io/docs/deployment/docker)
+- [Backstage container image](https://backstage.io/docs/deployment/docker) (by default this chart deploys vanilla upstream image without any modifications, users are encouraged to supply their own image)
 
 ## Installing the Chart
 
@@ -72,9 +72,9 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Name                            | Description                                                          | Value                                                                       |
 | ------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| `backstage.image.registry`      | Backstage image registry                                             | `""`                                                                        |
-| `backstage.image.repository`    | Backstage image repository (required)                                | `""`                                                                        |
-| `backstage.image.tag`           | Backstage image tag (required immutable tags are recommended)        | `""`                                                                        |
+| `backstage.image.registry`      | Backstage image registry                                             | `ghcr.io`                                                                   |
+| `backstage.image.repository`    | Backstage image repository (required)                                | `backstage/backstage`                                                       |
+| `backstage.image.tag`           | Backstage image tag (required immutable tags are recommended)        | `latest`                                                                    |
 | `backstage.image.pullPolicy`    | Backstage image pull policy                                          | `IfNotPresent`                                                              |
 | `backstage.image.pullSecrets`   | Specify docker-registry secret names as an array                     | `[]`                                                                        |
 | `backstage.command`             | Override Backstage container command                                 | `["node", "packages/backend"]`                                              |

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.2
+version: 0.5.3
 
 dependencies:
   - name: common

--- a/charts/backstage/ci/ci-values.yaml
+++ b/charts/backstage/ci/ci-values.yaml
@@ -1,5 +1,0 @@
-backstage:
-  image:
-    registry: ghcr.io
-    repository: janus-idp/redhat-backstage-build
-    tag: latest

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -86,9 +86,9 @@ ingress:
 
 backstage:
   image:
-    registry: ""
-    repository: ""
-    tag: ""
+    registry: ghcr.io
+    repository: backstage/backstage
+    tag: latest
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

This PR sets default image to `ghcr.io/backstage/backstage:latest` (removes CI override and sets it directly in the default values)

## Existing or Associated Issue(s)
 
Resolves: #12 #16 

## Additional Information

Image provided by @Rugvip https://github.com/backstage/charts/pull/8#discussion_r1042045587

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
