### PR TITLE
feat: Adds TLS for Ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingress.className`                | Name of the IngressClass cluster resource (e.g nginx)             | `""`        |
 | `ingress.annotations`              | Additional annotations for the Ingress resource                   | `{}`        |
 | `ingress.host`                     | Hostname of the backstage application (e.g backstage.<IP>.nip.io) | `""`        |
+| `ingress.tls.enabled`              | Enable TLS configuration for the host defined at `ingress.host`   | `false`     |
+| `ingress.tls.secretName`           | The name to which the TLS Secret will be called                   | `""`        |
 | `service.type`                     | Kubernetes Service type                                           | `ClusterIP` |
 | `service.ports.backend`            | Port for client connections                                       | `7007`      |
 | `service.nodePorts.backend`        | Node port for client connections                                  | `""`        |

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.3
+version: 0.6.0
 
 dependencies:
   - name: common

--- a/charts/backstage/templates/ingress.yaml
+++ b/charts/backstage/templates/ingress.yaml
@@ -20,6 +20,12 @@ spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className | quote }}
   {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+      - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end -}}
   rules:
     - host: {{ .Values.ingress.host }}
       http:

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -73,6 +73,15 @@ ingress:
   ## @param host Hostname to be used to expose the route to access the backstage application (e.g: backstage.IP.nip.io)
   host: ""
 
+  ## @section Ingress TLS parameters
+  tls:
+
+    ## @param ingress.tls.enabled Enable TLS configuration for the host defined at `ingress.host` parameter
+    enabled: false
+
+    ## @param ingress.tls.secretName The name to which the TLS Secret will be called
+    secretName: ""
+
 ## @section Backstage parameters
 
 ## Backstage image version


### PR DESCRIPTION
## Description of the change
Adds TLS Configuration for Ingress. Closes: https://github.com/backstage/charts/issues/2

## Checklist
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [N/A] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.

Have added the variables to the Values file and the `README.md` but we don't use `helm-docs` auto-generation at the moment. There was an open issue on this on the [old backstage chart repo](https://github.com/vinzscam/backstage-chart/issues/3) but we never actually implemented it. I feel we should raise a separate issue for this and track it separately.

Signed-off-by: ChrisJBurns <29541485+ChrisJBurns@users.noreply.github.com>
