### PR TITLE
feat: adds securityContexts (pod & container)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+### macOS ###
+.DS_Store
+.AppleDouble
+.LSOverride
+
+
+# helm chart dependencies
+charts/*/charts/
+**/charts/*.tgz

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.3
+version: 0.7.0
 
 dependencies:
   - name: common

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # Backstage Helm Chart
 
-![Version: 0.6.3](https://img.shields.io/badge/Version-0.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
 
@@ -89,6 +89,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | backstage.command[0] |  | string | `"node"` |
 | backstage.command[1] |  | string | `"packages/backend"` |
 | backstage.containerPorts.backend |  | int | `7007` |
+| backstage.containerSecurityContext |  | object | `{}` |
 | backstage.extraAppConfig |  | list | `[]` |
 | backstage.extraEnvVars |  | list | `[]` |
 | backstage.extraEnvVarsSecrets |  | string | `nil` |
@@ -100,6 +101,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | backstage.image.registry |  | string | `"ghcr.io"` |
 | backstage.image.repository |  | string | `"backstage/backstage"` |
 | backstage.image.tag |  | string | `"latest"` |
+| backstage.podSecurityContext |  | object | `{}` |
 | clusterDomain |  | string | `"cluster.local"` |
 | commonAnnotations |  | object | `{}` |
 | commonLabels |  | object | `{}` |

--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -28,6 +28,10 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- end }}     
+      {{- if .Values.backstage.podSecurityContext }}
+      securityContext:
+        {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.podSecurityContext "context" $) | nindent 8 }}
+      {{- end }}
       volumes:
         {{- if (or .Values.backstage.extraAppConfig (and .Values.backstage.extraVolumeMounts .Values.backstage.extraVolumes)) }}
         {{- range .Values.backstage.extraAppConfig }}
@@ -49,6 +53,10 @@ spec:
         - name: backstage-backend
           image: {{ include "backstage.image" . }}
           imagePullPolicy: {{ .Values.backstage.image.pullPolicy | quote -}}
+          {{- if .Values.backstage.containerSecurityContext }}
+          securityContext:
+            {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.podSecurityContext "context" $) | nindent 12 }}
+          {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
           {{- else if .Values.backstage.command }}

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -121,6 +121,15 @@ backstage:
   extraVolumeMounts: []
   extraVolumes: []
 
+  ## @param backstage.podSecurityContext Security settings for a Pod.
+  ## The security settings that you specify for a Pod apply to all Containers in the Pod.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  podSecurityContext: {}
+
+  ## @param backstage.containerSecurityContext Security settings for a Container
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  containerSecurityContext: {}
+
 ## @section Traffic Exposure parameters
 
 ## Service parameters


### PR DESCRIPTION
## Description of the change
- Adds Security Context for Pod and Containers. Closes: https://github.com/backstage/charts/issues/3
- Adds `.gitignore` to avoid chart dependencies and their `.tgz`'s being added and to ignore common MacOS files

## Checklist
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [N/A] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.

Signed-off-by: ChrisJBurns <29541485+ChrisJBurns@users.noreply.github.com>