### PR TITLE
Bugfix: Fix ingress error causing spec and Rules to be on single line

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.1
+version: 0.6.2
 
 dependencies:
   - name: common

--- a/charts/backstage/templates/ingress.yaml
+++ b/charts/backstage/templates/ingress.yaml
@@ -25,7 +25,7 @@ spec:
     - hosts:
       - {{ .Values.ingress.host }}
       secretName: {{ .Values.ingress.tls.secretName }}
-  {{- end -}}
+  {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change
Introduced recently in the TLS section is the {{- end -}} where we suppress the newline. This causes the rules to end up on the same line as the previous section and would break the schema and get something like spec:rules: which is invalid

<!-- Describe the change being requested. -->
Changes the {{- end -}} for the TLS section of the ingress to not suppress the newline

## Existing or Associated Issue(s)
Fixes: https://github.com/backstage/charts/issues/21
<!-- List any related issues. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
