### PR TITLE
feat: define extra app config which generates ConfigMap

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.10.0
 
 dependencies:
   - name: common

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -242,7 +242,9 @@ The chart will mount the content of the ConfigMap as a new `app-config.extra.yam
 
 ### Pass configuration to be stored in a ConfigMap
 
-Instead of following the previus step (`Pass extra configuration files`), you can get the Config Map automatically deployed with this Helm Chart by defining the key `appConfig`:
+> :warning: In case of using both appConfig and extraAppConfig, appConfig will have higher priority over extraAppConfig.
+
+In addition to following the previus step (`Pass extra configuration files`), you can get the Config Map automatically deployed with this Helm Chart by defining the key `appConfig`:
 
 ```diff
   backstage:

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -85,7 +85,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Key | Description | Type | Default |
 |-----|-------------|------|---------|
-| backstage.appConfig | Generates ConfigMap and configures it in the Backstage pods | string | `nil` |
+| backstage.appConfig | Generates ConfigMap and configures it in the Backstage pods | object | `{}` |
 | backstage.args |  | list | `[]` |
 | backstage.command[0] |  | string | `"node"` |
 | backstage.command[1] |  | string | `"packages/backend"` |
@@ -239,6 +239,19 @@ Now that the ConfigMap has been created on your Kubernetes cluster, you can refe
 ```
 
 The chart will mount the content of the ConfigMap as a new `app-config.extra.yaml` file and automatically pass the extra configuration to your instance.
+
+### Pass configuration to be stored in a ConfigMap
+
+Instead of following the previus step (`Pass extra configuration files`), you can get the Config Map automatically deployed with this Helm Chart by defining the key `appConfig`:
+
+```diff
+  backstage:
++   appConfig:
++     app:
++       baseUrl: https://somedomain.tld
+```
+
+The chart will mount the content of the ConfigMap as a new `app-config-from-configmap.yaml` file and automatically pass the extra configuration to your instance.
 
 ### Configuring Chart PostgreSQL
 

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -85,6 +85,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Key | Description | Type | Default |
 |-----|-------------|------|---------|
+| backstage.appConfig | Generates ConfigMap and configures it in the Backstage pods | string | `nil` |
 | backstage.args |  | list | `[]` |
 | backstage.command[0] |  | string | `"node"` |
 | backstage.command[1] |  | string | `"packages/backend"` |

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -242,9 +242,9 @@ The chart will mount the content of the ConfigMap as a new `app-config.extra.yam
 
 ### Pass configuration to be stored in a ConfigMap
 
-> :warning: In case of using both appConfig and extraAppConfig, appConfig will have higher priority over extraAppConfig.
+> :warning: In case of using both appConfig and extraAppConfig, appConfig will have higher priority over extraAppConfig. For more information you can check the [Backstage docs](https://backstage.io/docs/conf/writing#configuration-files) and how this [Helm Chart configures the Backstage arguments](templates/backstage-deployment.yaml)
 
-In addition to following the previus step (`Pass extra configuration files`), you can get the Config Map automatically deployed with this Helm Chart by defining the key `appConfig`:
+In addition to following the [previus step "Pass extra configuration files"](#pass-extra-configuration-files), you can get the Config Map automatically deployed with this Helm Chart by defining the key `appConfig`:
 
 ```diff
   backstage:

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -244,7 +244,7 @@ The chart will mount the content of the ConfigMap as a new `app-config.extra.yam
 
 > :warning: In case of using both appConfig and extraAppConfig, appConfig will have higher priority over extraAppConfig. For more information you can check the [Backstage docs](https://backstage.io/docs/conf/writing#configuration-files) and how this [Helm Chart configures the Backstage arguments](templates/backstage-deployment.yaml)
 
-In addition to following the [previus step "Pass extra configuration files"](#pass-extra-configuration-files), you can get the Config Map automatically deployed with this Helm Chart by defining the key `appConfig`:
+In addition to following the [previous step "Pass extra configuration files"](#pass-extra-configuration-files), you can get the Config Map automatically deployed with this Helm Chart by defining the key `appConfig`:
 
 ```diff
   backstage:

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # Backstage Helm Chart
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
 

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -172,7 +172,9 @@ The chart will mount the content of the ConfigMap as a new `app-config.extra.yam
 
 ### Pass configuration to be stored in a ConfigMap
 
-Instead of following the previus step (`Pass extra configuration files`), you can get the Config Map automatically deployed with this Helm Chart by defining the key `appConfig`:
+> :warning: In case of using both appConfig and extraAppConfig, appConfig will have higher priority over extraAppConfig.
+
+In addition to following the previus step (`Pass extra configuration files`), you can get the Config Map automatically deployed with this Helm Chart by defining the key `appConfig`:
 
 ```diff
   backstage:

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -174,7 +174,7 @@ The chart will mount the content of the ConfigMap as a new `app-config.extra.yam
 
 > :warning: In case of using both appConfig and extraAppConfig, appConfig will have higher priority over extraAppConfig. For more information you can check the [Backstage docs](https://backstage.io/docs/conf/writing#configuration-files) and how this [Helm Chart configures the Backstage arguments](templates/backstage-deployment.yaml)
 
-In addition to following the [previus step "Pass extra configuration files"](#pass-extra-configuration-files), you can get the Config Map automatically deployed with this Helm Chart by defining the key `appConfig`:
+In addition to following the [previous step "Pass extra configuration files"](#pass-extra-configuration-files), you can get the Config Map automatically deployed with this Helm Chart by defining the key `appConfig`:
 
 ```diff
   backstage:

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -174,7 +174,7 @@ The chart will mount the content of the ConfigMap as a new `app-config.extra.yam
 
 > :warning: In case of using both appConfig and extraAppConfig, appConfig will have higher priority over extraAppConfig.
 
-In addition to following the previus step (`Pass extra configuration files`), you can get the Config Map automatically deployed with this Helm Chart by defining the key `appConfig`:
+In addition to following the [previus step](#pass-extra-configuration-files), you can get the Config Map automatically deployed with this Helm Chart by defining the key `appConfig`:
 
 ```diff
   backstage:

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -172,9 +172,9 @@ The chart will mount the content of the ConfigMap as a new `app-config.extra.yam
 
 ### Pass configuration to be stored in a ConfigMap
 
-> :warning: In case of using both appConfig and extraAppConfig, appConfig will have higher priority over extraAppConfig.
+> :warning: In case of using both appConfig and extraAppConfig, appConfig will have higher priority over extraAppConfig. For more information you can check the [Backstage docs](https://backstage.io/docs/conf/writing#configuration-files) and how this [Helm Chart configures the Backstage arguments](templates/backstage-deployment.yaml)
 
-In addition to following the [previus step](#pass-extra-configuration-files), you can get the Config Map automatically deployed with this Helm Chart by defining the key `appConfig`:
+In addition to following the [previus step "Pass extra configuration files"](#pass-extra-configuration-files), you can get the Config Map automatically deployed with this Helm Chart by defining the key `appConfig`:
 
 ```diff
   backstage:

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -170,6 +170,19 @@ Now that the ConfigMap has been created on your Kubernetes cluster, you can refe
 
 The chart will mount the content of the ConfigMap as a new `app-config.extra.yaml` file and automatically pass the extra configuration to your instance.
 
+### Pass configuration to be stored in a ConfigMap
+
+Instead of following the previus step (`Pass extra configuration files`), you can get the Config Map automatically deployed with this Helm Chart by defining the key `appConfig`:
+
+```diff
+  backstage:
++   appConfig:
++     app:
++       baseUrl: https://somedomain.tld
+```
+
+The chart will mount the content of the ConfigMap as a new `app-config-from-configmap.yaml` file and automatically pass the extra configuration to your instance.
+
 ### Configuring Chart PostgreSQL
 
 With the Backstage Helm Chart, it offers - as a subchart - a Bitnami PostgreSQL database. This can be enabled by switching `postgresql.enabled` to true (it is `false` by default). If switched on, the Helm Chart, on deployment, will automatically deploy a PostgreSQL instance and configure it with the credentials you specify. There are multiple ways of doing this that will be detailed below.

--- a/charts/backstage/ci/appConfig-values.yaml
+++ b/charts/backstage/ci/appConfig-values.yaml
@@ -1,0 +1,10 @@
+backstage:
+  appConfig:
+    app:
+      # Let's test that everything is fine with comments
+      title: The very best Backstage Helm Chart! :D
+      baseUrl: https://somedomain.tl
+    backend:
+      baseUrl: https://somedomain.tl
+      listen:
+        port: 12345

--- a/charts/backstage/ci/extraVolumes-values.yaml
+++ b/charts/backstage/ci/extraVolumes-values.yaml
@@ -1,0 +1,12 @@
+backstage:
+  extraVolumeMounts:
+    - name: backstage-secretstore
+      mountPath: /mnt/secretstore
+      readOnly: true
+  extraVolumes:
+    - name: backstage-secretstore
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: backstage-secretstore

--- a/charts/backstage/ci/extraVolumes-values.yaml
+++ b/charts/backstage/ci/extraVolumes-values.yaml
@@ -1,12 +1,9 @@
 backstage:
   extraVolumeMounts:
-    - name: backstage-secretstore
-      mountPath: /mnt/secretstore
+    - name: test
+      mountPath: /somepath
       readOnly: true
   extraVolumes:
-    - name: backstage-secretstore
-      csi:
-        driver: secrets-store.csi.k8s.io
-        readOnly: true
-        volumeAttributes:
-          secretProviderClass: backstage-secretstore
+    - name: test
+      emptyDir:
+        sizeLimit: 5Mi

--- a/charts/backstage/templates/app-config-configmap.yaml
+++ b/charts/backstage/templates/app-config-configmap.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.backstage.appConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backstage-app-config
+data:
+  app-config.yaml: {{ toYaml .Values.backstage.appConfig | indent 2 }}
+{{- end }}

--- a/charts/backstage/templates/app-config-configmap.yaml
+++ b/charts/backstage/templates/app-config-configmap.yaml
@@ -5,5 +5,5 @@ metadata:
   name: backstage-app-config
 data:
   app-config.yaml: |
-    {{- toYaml .Values.backstage.appConfig | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.appConfig "context" $) | nindent 4 }}
 {{- end }}

--- a/charts/backstage/templates/app-config-configmap.yaml
+++ b/charts/backstage/templates/app-config-configmap.yaml
@@ -4,5 +4,6 @@ kind: ConfigMap
 metadata:
   name: backstage-app-config
 data:
-  app-config.yaml: {{ toYaml .Values.backstage.appConfig | indent 2 }}
+  app-config.yaml: |
+    {{- toYaml .Values.backstage.appConfig | nindent 4 }}
 {{- end }}

--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -43,6 +43,11 @@ spec:
           {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.extraVolumes "context" $ ) | nindent 8 }}
         {{- end }}
         {{- end }}
+        {{- if .Values.backstage.appConfig }}
+        - name: backstage-app-config
+          configMap:
+            name: backstage-app-config
+        {{- end }}
       {{- if .Values.backstage.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.backstage.image.pullSecrets }}
@@ -83,6 +88,10 @@ spec:
             - {{ .filename | quote }}
           {{- end }}
           {{- end }}
+          {{- if .Values.backstage.appConfig }}
+            - "--config"
+            - "app-config-from-configmap.yaml"
+          {{- end }}
           {{- end }}
           {{- if .Values.backstage.extraEnvVarsSecrets }}
           envFrom:
@@ -114,12 +123,17 @@ spec:
             - name: backend
               containerPort: {{ .Values.backstage.containerPorts.backend }}
               protocol: TCP
-          {{- if (or .Values.backstage.extraAppConfig (and .Values.backstage.extraVolumeMounts .Values.backstage.extraVolumes)) }}
+          {{- if (or .Values.backstage.extraAppConfig .Values.backstage.appConfig (and .Values.backstage.extraVolumeMounts .Values.backstage.extraVolumes)) }}
           volumeMounts:
             {{- range .Values.backstage.extraAppConfig }}
             - name: {{ .configMapRef }}
               mountPath: "/app/{{ .filename }}"
               subPath: {{ .filename }}
+            {{- end }}
+            {{- if .Values.backstage.appConfig }}
+            - name: backstage-app-config
+              mountPath: /app/app-config-from-configmap.yaml
+              subPath: app-config.yaml
             {{- end }}
             {{- if .Values.backstage.extraVolumeMounts }}
               {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.extraVolumeMounts "context" $ ) | nindent 12 }}

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -147,11 +147,11 @@ backstage:
   # automatically, not requiring to have it pre provisioned as with the extraAppConfig key.
   # DO NOT USE if you need to put sensitive data in the appConfig.
   # E.g:
-  # appConfig: |
+  # appConfig:
   #   app:
   #     baseUrl: https://somedomain.tld
   # -- Generates ConfigMap and configures it in the Backstage pods
-  appConfig: null
+  appConfig: {}
 
 ## @section Traffic Exposure parameters
 

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -143,6 +143,16 @@ backstage:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   containerSecurityContext: {}
 
+  # Allows to define the appConfig as a multiline string that generates a ConfigMap
+  # automatically, not requiring to have it pre provisioned as with the extraAppConfig key.
+  # DO NOT USE if you need to put sensitive data in the appConfig.
+  # E.g:
+  # appConfig: |
+  #   app:
+  #     baseUrl: https://somedomain.tld
+  # -- Generates ConfigMap and configures it in the Backstage pods
+  appConfig: null
+
 ## @section Traffic Exposure parameters
 
 ## Service parameters


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

This PR was originally started at: https://github.com/vinzscam/backstage-chart/pull/24

As it was discussed a little bit at https://github.com/vinzscam/backstage-chart/issues/4:

I think it would be nice to give the possibility to define an extra app config file in the values.yaml, which then creates a ConfigMap automatically, mounts it and uses it in the config.

Please, let me know your thoughts, and if there is anything I should improve or change. :)

## Additional Information

The problem with the current approach is that the ConfigMap needs to be provided externally from this Helm chart. It is not a big deal, but I think it would be nice to provide both things, generating the ConfigMap in the Helm chart itself, and also allowing us to define the config in the values.yaml file. In the end the idea of the values.yaml file is to be the place where the applications can be configured.

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
