### PR TITLE
Feature: Resource Limits for backstage container

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.7.1
 
 dependencies:
   - name: common

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.2
+version: 0.7.0
 
 dependencies:
   - name: common

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.1
+version: 0.8.0
 
 dependencies:
   - name: common

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # Backstage Helm Chart
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
 
@@ -101,8 +101,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | backstage.image.registry |  | string | `"ghcr.io"` |
 | backstage.image.repository |  | string | `"backstage/backstage"` |
 | backstage.image.tag |  | string | `"latest"` |
-| backstage.resources |  | object | `{}` |
 | backstage.podSecurityContext |  | object | `{}` |
+| backstage.resources |  | object | `{}` |
 | clusterDomain |  | string | `"cluster.local"` |
 | commonAnnotations |  | object | `{}` |
 | commonLabels |  | object | `{}` |

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # Backstage Helm Chart
 
-![Version: 0.6.3](https://img.shields.io/badge/Version-0.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
 
@@ -100,6 +100,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | backstage.image.registry |  | string | `"ghcr.io"` |
 | backstage.image.repository |  | string | `"backstage/backstage"` |
 | backstage.image.tag |  | string | `"latest"` |
+| backstage.resources |  | object | `{}` |
 | clusterDomain |  | string | `"cluster.local"` |
 | commonAnnotations |  | object | `{}` |
 | commonLabels |  | object | `{}` |

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -102,7 +102,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | backstage.image.repository |  | string | `"backstage/backstage"` |
 | backstage.image.tag |  | string | `"latest"` |
 | backstage.podSecurityContext |  | object | `{}` |
-| backstage.resources |  | object | `{}` |
+| backstage.resources | resource requests/limits ref: https://kubernetes.io/docs/user-guide/compute-resources/ # E.g. # resources: #   limits: #     memory: 1Gi #     cpu: 1000m #   requests: #     memory: 250Mi #     cpu: 100m | object | `{}` |
 | clusterDomain |  | string | `"cluster.local"` |
 | commonAnnotations |  | object | `{}` |
 | commonLabels |  | object | `{}` |

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # Backstage Helm Chart
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
 

--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -27,14 +27,14 @@ spec:
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
-      {{- end }}     
+      {{- end }}
       volumes:
         {{- if (or .Values.backstage.extraAppConfig (and .Values.backstage.extraVolumeMounts .Values.backstage.extraVolumes)) }}
         {{- range .Values.backstage.extraAppConfig }}
         - name: {{ .configMapRef }}
           configMap:
             name: {{ .configMapRef }}
-        {{- end }}            
+        {{- end }}
         {{- if .Values.backstage.extraVolumes }}
           {{- toYaml .Values.backstage.extraVolumes | nindent 8 }}
         {{- end }}
@@ -62,6 +62,9 @@ spec:
           {{- range .Values.backstage.args }}
             - {{ . | quote }}
           {{- end }}
+          {{- if .Values.backstage.resources }}
+          resources: {{- toYaml .Values.backstage.resources | nindent 12 }}
+          {{- end }}
           {{- if .Values.backstage.extraAppConfig }}
           {{- range .Values.backstage.extraAppConfig }}
             - "--config"
@@ -84,7 +87,7 @@ spec:
               value: {{ include "backstage.postgresql.host" . }}
             - name: POSTGRES_PORT
               value: "5432"
-            - name: POSTGRES_USER     
+            - name: POSTGRES_USER
               value: {{ .Values.postgresql.auth.username }}
             - name: POSTGRES_PASSWORD
               valueFrom:
@@ -104,7 +107,7 @@ spec:
             {{- range .Values.backstage.extraAppConfig }}
             - name: {{ .configMapRef }}
               mountPath: "/app/{{ .filename }}"
-              subPath: {{ .filename }} 
+              subPath: {{ .filename }}
             {{- end }}
             {{- if .Values.backstage.extraVolumeMounts }}
               {{- toYaml .Values.backstage.extraVolumeMounts | nindent 12 }}

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -127,7 +127,7 @@ backstage:
   ## @param resources.requests.memory The requested memory for the backstage containers
   ## @param resources.requests.cpu The requested cpu for the backstage containers
   ##
-  #resources:
+  # resources:
   #  limits:
   #    memory: 1Gi
   #    cpu: 1000m

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -127,6 +127,7 @@ backstage:
   ## @param resources.requests.memory The requested memory for the backstage containers
   ## @param resources.requests.cpu The requested cpu for the backstage containers
   ##
+  resources: {}
   # resources:
   #  limits:
   #    memory: 1Gi

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -120,6 +120,20 @@ backstage:
   extraEnvVarsSecrets:
   extraVolumeMounts: []
   extraVolumes: []
+  ## backstage resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param resources.limits.memory The resources limits for the backstage containers memory
+  ## @param resources.limits.cpu The resources limits for the backstage containers cpu
+  ## @param resources.requests.memory The requested memory for the backstage containers
+  ## @param resources.requests.cpu The requested cpu for the backstage containers
+  ##
+  #resources:
+  #  limits:
+  #    memory: 1Gi
+  #    cpu: 1000m
+  #  requests:
+  #    memory: 250Mi
+  #    cpu: 100m
 
 ## @section Traffic Exposure parameters
 

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -120,21 +120,17 @@ backstage:
   extraEnvVarsSecrets:
   extraVolumeMounts: []
   extraVolumes: []
-  ## backstage resource requests and limits
-  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-  ## @param resources.limits.memory The resources limits for the backstage containers memory
-  ## @param resources.limits.cpu The resources limits for the backstage containers cpu
-  ## @param resources.requests.memory The requested memory for the backstage containers
-  ## @param resources.requests.cpu The requested cpu for the backstage containers
-  ##
+  # -- resource requests/limits
+  # ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## E.g.
+  ## resources:
+  ##   limits:
+  ##     memory: 1Gi
+  ##     cpu: 1000m
+  ##   requests:
+  ##     memory: 250Mi
+  ##     cpu: 100m
   resources: {}
-  # resources:
-  #  limits:
-  #    memory: 1Gi
-  #    cpu: 1000m
-  #  requests:
-  #    memory: 250Mi
-  #    cpu: 100m
 
   ## @param backstage.podSecurityContext Security settings for a Pod.
   ## The security settings that you specify for a Pod apply to all Containers in the Pod.


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change
Adds support for setting requests and limits on the backstage deployment such that folks can execute to their desired best practices on resource consolidation.

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)
https://github.com/backstage/charts/issues/26

<!-- List any related issues. -->

## Additional Information
Looked over my local developer deployment that has a number of added plugins and a few charts etc and what the resource limits were. Set memory fairly high comparatively but cpu should be fully in line.

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
