### PR TITLE
Added support for extraContainers and initContainers

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.9.0
 
 dependencies:
   - name: common

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # Backstage Helm Chart
 
-![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
 
@@ -91,6 +91,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | backstage.containerPorts.backend |  | int | `7007` |
 | backstage.containerSecurityContext |  | object | `{}` |
 | backstage.extraAppConfig |  | list | `[]` |
+| backstage.extraContainers |  | list | `[]` |
 | backstage.extraEnvVars |  | list | `[]` |
 | backstage.extraEnvVarsSecrets |  | string | `nil` |
 | backstage.extraVolumeMounts |  | list | `[]` |
@@ -101,6 +102,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | backstage.image.registry |  | string | `"ghcr.io"` |
 | backstage.image.repository |  | string | `"backstage/backstage"` |
 | backstage.image.tag |  | string | `"latest"` |
+| backstage.initContainers |  | list | `[]` |
 | backstage.podSecurityContext |  | object | `{}` |
 | backstage.resources | resource requests/limits ref: https://kubernetes.io/docs/user-guide/compute-resources/ # E.g. # resources: #   limits: #     memory: 1Gi #     cpu: 1000m #   requests: #     memory: 250Mi #     cpu: 100m | object | `{}` |
 | clusterDomain |  | string | `"cluster.local"` |

--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -49,6 +49,10 @@ spec:
           - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if .Values.backstage.initContainers }}
+      initContainers:
+        {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.initContainers "context" $) | nindent 8 }}
+      {{- end }}
       containers:
         - name: backstage-backend
           image: {{ include "backstage.image" . }}
@@ -121,3 +125,6 @@ spec:
               {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
           {{- end }}
+        {{- if .Values.backstage.extraContainers }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.extraContainers "context" $) | nindent 8 }}
+        {{- end }}

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -116,10 +116,12 @@ backstage:
   command: ["node", "packages/backend"]
   args: []
   extraAppConfig: []
+  extraContainers: []
   extraEnvVars: []
   extraEnvVarsSecrets:
   extraVolumeMounts: []
   extraVolumes: []
+  initContainers: []
   # -- resource requests/limits
   # ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## E.g.


### PR DESCRIPTION
## Description of the change

Adds support for providing extra containers and initContainers to the backstage Deployment

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
