### PR TITLE
Migrate toYaml to partial

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.8.1
 
 dependencies:
   - name: common

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # Backstage Helm Chart
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
 

--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -40,7 +40,7 @@ spec:
             name: {{ .configMapRef }}
         {{- end }}
         {{- if .Values.backstage.extraVolumes }}
-          {{- toYaml .Values.backstage.extraVolumes | nindent 8 }}
+          {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.extraVolumes "context" $ ) | nindent 8 }}
         {{- end }}
         {{- end }}
       {{- if .Values.backstage.image.pullSecrets }}
@@ -118,6 +118,6 @@ spec:
               subPath: {{ .filename }}
             {{- end }}
             {{- if .Values.backstage.extraVolumeMounts }}
-              {{- toYaml .Values.backstage.extraVolumeMounts | nindent 12 }}
+              {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
           {{- end }}

--- a/charts/backstage/templates/serviceaccount.yaml
+++ b/charts/backstage/templates/serviceaccount.yaml
@@ -7,12 +7,12 @@ metadata:
   labels:
     app.kubernetes.io/component: backstage
     {{- with .Values.serviceAccount.labels }}
-    {{- toYaml . | trim | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | trim | nindent 4 }}
     {{- end }}
   {{- if .Values.serviceAccount.annotations }}
   annotations:
     {{- with .Values.serviceAccount.annotations }}
-    {{- toYaml . | trim | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | trim | nindent 4 }}
     {{- end }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}


### PR DESCRIPTION
## Description of the change

Migrate toYaml to reusable partial

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
