### PR TITLE
Enable the ability to specify the service target port

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.1
+version: 0.11.0
 
 dependencies:
   - name: common

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # Backstage Helm Chart
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
 
@@ -151,7 +151,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | service.loadBalancerIP | Backstage service Load Balancer IP  <br /> Ref: https://kubernetes.io/docs/user-guide/services/#type-loadbalancer | string | `""` |
 | service.loadBalancerSourceRanges | Load Balancer sources  <br /> Ref: https://kubernetes.io/docs/tasks/access-application-cluster/cnfigure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service <br /> E.g `loadBalancerSourceRanges: [10.10.10.0/24]` | list | `[]` |
 | service.nodePorts | Node port for the Backstage client connections Choose port between `30000-32767` | object | `{"backend":""}` |
-| service.ports | Backstage svc port for client connections | object | `{"backend":7007}` |
+| service.ports | Backstage svc port for client connections | object | `{"backend":7007,"targetPort":"backend"}` |
+| service.ports.targetPort | Backstage svc target port referencing receiving pod container port | string | `"backend"` |
 | service.sessionAffinity | Control where client requests go, to the same pod or round-robin (values: `ClientIP` or `None`) <br /> Ref: https://kubernetes.io/docs/user-guide/services/ | string | `"None"` |
 | service.type | Kubernetes Service type | string | `"ClusterIP"` |
 | serviceAccount | Service Account Configuration | object | See below |

--- a/charts/backstage/templates/service.yaml
+++ b/charts/backstage/templates/service.yaml
@@ -37,7 +37,7 @@ spec:
   ports:
     - name: http-backend
       port: {{ .Values.service.ports.backend }}
-      targetPort: backend
+      targetPort: {{ .Values.service.ports.targetPort }}
       protocol: TCP
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.backend)) }}
       nodePort: {{ .Values.service.nodePorts.backend }}

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -181,6 +181,9 @@ service:
   ports:
     backend: 7007
 
+    # -- Backstage svc target port referencing receiving pod container port
+    targetPort: backend
+
   # -- Node port for the Backstage client connections
   # Choose port between `30000-32767`
   nodePorts:


### PR DESCRIPTION
## Description of the change

Enable the ability to specify the service target port to avoid hardcoded value

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
