### PR TITLE
chore: Generate release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,9 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968 # pin@v1.4.0
+        uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968 # pin@v1.5.0
+        with:
+          config: cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,0 +1,2 @@
+generate-release-notes: true
+


### PR DESCRIPTION
Start using the flag introduced in https://github.com/helm/chart-releaser/releases/tag/v1.5.0 which relies on GitHub to generate release notes automatically.

Resolves #24 

