### PR TITLE
feat: Add ServiceMonitor for Prometheus operator

### DIFF
--- a/charts/backstage/Chart.lock
+++ b/charts/backstage/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.0
+  version: 1.17.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.6
-digest: sha256:5f0f118ac2ae2be90edd9c6952da4bcb41feb815b39a575e23ec2a0a9244d9cd
-generated: "2022-06-14T21:14:00.148159+01:00"
+  version: 11.9.13
+digest: sha256:e24333442ed7bee23fd4d0ae522d3e8c56fd212e4ff33f020ad12f1528ae78e9
+generated: "2023-02-09T14:22:13.567819+01:00"

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.16.0
+version: 0.17.0
 
 dependencies:
   - name: common

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.2
+version: 0.16.0
 
 dependencies:
   - name: common

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -136,7 +136,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | metrics.serviceMonitor.enabled | If enabled, a ServiceMonitor resource for Prometheus Operator is created <br /> Prometheus Operator must be installed in your cluster prior to enabling. | bool | `false` |
 | metrics.serviceMonitor.interval | ServiceMonitor scrape interval | string | `nil` |
 | metrics.serviceMonitor.labels | Additional ServiceMonitor labels | object | `{}` |
-| metrics.serviceMonitor.path | ServiceMonitor endpoint path <br /> Note that the /metrics endpoint is NOT present in a freshly scaffolded Backstage app. To setup, follow the [Prometheus metrics tutorial](https://github.com/backstage/backstage/blob/6f7eb97c755224bca1915050c4505d4d4a7ed60a/contrib/docs/tutorials/prometheus-metrics.md). | string | `"/metrics"` |
+| metrics.serviceMonitor.path | ServiceMonitor endpoint path <br /> Note that the /metrics endpoint is NOT present in a freshly scaffolded Backstage app. To setup, follow the [Prometheus metrics tutorial](https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/prometheus-metrics.md). | string | `"/metrics"` |
 | nameOverride | String to partially override common.names.fullname | string | `""` |
 | networkPolicy | Network policies <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/ | object | `{"egressRules":{"customRules":[]},"enabled":false,"externalAccess":{"from":[]}}` |
 | networkPolicy.egressRules | Custom network policy rule | object | `{"customRules":[]}` |

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -129,6 +129,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | ingress.tls.enabled | Enable TLS configuration for the host defined at `ingress.host` parameter | bool | `false` |
 | ingress.tls.secretName | The name to which the TLS Secret will be called | string | `""` |
 | kubeVersion | Override Kubernetes version | string | `""` |
+| metrics | Metrics configuration | object | `{"serviceMonitor":{"annotations":{},"enabled":false,"interval":null,"labels":{},"path":"/metrics"}}` |
+| metrics.serviceMonitor | ServiceMonitor configuration <br /> Allows configuring your backstage instance as a scrape target for [Prometheus](https://github.com/prometheus/prometheus) using a ServiceMonitor custom resource that [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) can understand. | object | `{"annotations":{},"enabled":false,"interval":null,"labels":{},"path":"/metrics"}` |
+| metrics.serviceMonitor.annotations | ServiceMonitor annotations | object | `{}` |
+| metrics.serviceMonitor.enabled | If enabled, a ServiceMonitor resource for Prometheus Operator is created <br /> Prometheus Operator must be installed in your cluster prior to enabling. | bool | `false` |
+| metrics.serviceMonitor.interval | ServiceMonitor scrape interval | string | `nil` |
+| metrics.serviceMonitor.labels | Additional ServiceMonitor labels | object | `{}` |
+| metrics.serviceMonitor.path | ServiceMonitor endpoint path <br /> Note that the /metrics endpoint is NOT present in a freshly scaffolded Backstage app. To setup, follow the [Prometheus metrics tutorial](https://github.com/backstage/backstage/blob/6f7eb97c755224bca1915050c4505d4d4a7ed60a/contrib/docs/tutorials/prometheus-metrics.md). | string | `"/metrics"` |
 | nameOverride | String to partially override common.names.fullname | string | `""` |
 | networkPolicy | Network policies <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/ | object | `{"egressRules":{"customRules":[]},"enabled":false,"externalAccess":{"from":[]}}` |
 | networkPolicy.egressRules | Custom network policy rule | object | `{"customRules":[]}` |
@@ -163,12 +170,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | serviceAccount.create | Enable the creation of a ServiceAccount for Backstage pods | bool | `false` |
 | serviceAccount.labels | Additional custom labels to the service ServiceAccount. | object | `{}` |
 | serviceAccount.name | Name of the ServiceAccount to use If not set and `serviceAccount.create` is true, a name is generated | string | `""` |
-| serviceMonitor.annotations | ServiceMonitor annotations | object | `{}` |
-| serviceMonitor.enabled | If enabled, ServiceMonitor resources for Prometheus Operator are created | bool | `false` |
-| serviceMonitor.interval | ServiceMonitor scrape interval | string | `nil` |
-| serviceMonitor.labels | Additional ServiceMonitor labels | object | `{}` |
-| serviceMonitor.namespaceSelector | Namespace selector for ServiceMonitor resources | object | `{}` |
-| serviceMonitor.path | ServiceMonitor endpoint path | string | `"/metrics"` |
 
 ## Configure your Backstage instance
 

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # Backstage Helm Chart
 
-![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
 

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # Backstage Helm Chart
 
-![Version: 0.15.2](https://img.shields.io/badge/Version-0.15.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
 
@@ -163,6 +163,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | serviceAccount.create | Enable the creation of a ServiceAccount for Backstage pods | bool | `false` |
 | serviceAccount.labels | Additional custom labels to the service ServiceAccount. | object | `{}` |
 | serviceAccount.name | Name of the ServiceAccount to use If not set and `serviceAccount.create` is true, a name is generated | string | `""` |
+| serviceMonitor.annotations | ServiceMonitor annotations | object | `{}` |
+| serviceMonitor.enabled | If enabled, ServiceMonitor resources for Prometheus Operator are created | bool | `false` |
+| serviceMonitor.interval | ServiceMonitor scrape interval | string | `nil` |
+| serviceMonitor.labels | Additional ServiceMonitor labels | object | `{}` |
+| serviceMonitor.namespaceSelector | Namespace selector for ServiceMonitor resources | object | `{}` |
+| serviceMonitor.path | ServiceMonitor endpoint path | string | `"/metrics"` |
 
 ## Configure your Backstage instance
 

--- a/charts/backstage/templates/servicemonitor.yaml
+++ b/charts/backstage/templates/servicemonitor.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
     {{- if .Values.metrics.serviceMonitor.annotations }}
-    {{ toYaml .Values.metrics.serviceMonitor.annotations | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.annotations "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
   labels: {{ include "common.labels.standard" . | nindent 4 }}
@@ -18,8 +18,8 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-    {{- with .Values.metrics.serviceMonitor.labels }}
-    {{- toYaml . | nindent 4 }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.labels "context" $) | nindent 4 }}
     {{- end }}
 spec:
   namespaceSelector:

--- a/charts/backstage/templates/servicemonitor.yaml
+++ b/charts/backstage/templates/servicemonitor.yaml
@@ -1,32 +1,37 @@
-{{- with .Values.serviceMonitor }}
-{{- if .enabled }}
+{{- if .Values.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "common.names.fullname" $ }}
-  namespace: {{ $.Release.Namespace | quote }}
-  {{- with .annotations }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- if or .Values.commonAnnotations .Values.metrics.serviceMonitor.annotations  }}
   annotations:
-    {{ toYaml . | nindent 4 }}
+    {{- if $.Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.metrics.serviceMonitor.annotations }}
+    {{ toYaml .Values.metrics.serviceMonitor.annotations | nindent 4 }}
+    {{- end }}
   {{- end }}
-  labels: {{ include "common.labels.standard" $ | nindent 4 }}
+  labels: {{ include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: backstage
-    {{- with .labels }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- with .namespaceSelector }}
   namespaceSelector:
-  {{- toYaml . | nindent 4 }}
-  {{- end }}
+    matchNames:
+      - {{ .Release.Namespace | quote }}
   selector:
-    matchLabels: {{ include "common.labels.standard" $ | nindent 6 }}
+    matchLabels: {{ include "common.labels.standard" . | nindent 6 }}
       app.kubernetes.io/component: backstage
   endpoints:
   - port: http-backend
-    path: {{ .path }}
-    {{- with .interval }}
+    path: {{ .Values.metrics.serviceMonitor.path }}
+    {{- with .Values.metrics.serviceMonitor.interval }}
     interval: {{ . }}
     {{- end }}
-{{- end -}}
 {{- end -}}

--- a/charts/backstage/templates/servicemonitor.yaml
+++ b/charts/backstage/templates/servicemonitor.yaml
@@ -1,0 +1,32 @@
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "common.names.fullname" $ }}
+  namespace: {{ $.Release.Namespace | quote }}
+  {{- with .annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+  labels: {{ include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/component: backstage
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels: {{ include "common.labels.standard" $ | nindent 6 }}
+      app.kubernetes.io/component: backstage
+  endpoints:
+  - port: http-backend
+    path: {{ .path }}
+    {{- with .interval }}
+    interval: {{ . }}
+    {{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -308,3 +308,18 @@ serviceAccount:
 
   # -- Auto-mount the service account token in the pod
   automountServiceAccountToken: true
+
+# ServiceMonitor configuration
+serviceMonitor:
+  # -- If enabled, ServiceMonitor resources for Prometheus Operator are created
+  enabled: false
+  # -- Namespace selector for ServiceMonitor resources
+  namespaceSelector: {}
+  # -- ServiceMonitor annotations
+  annotations: {}
+  # -- Additional ServiceMonitor labels
+  labels: {}
+  # -- ServiceMonitor scrape interval
+  interval: null
+  # -- ServiceMonitor endpoint path
+  path: /metrics

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -333,5 +333,5 @@ metrics:
     interval: null
 
     # -- ServiceMonitor endpoint path
-    # <br /> Note that the /metrics endpoint is NOT present in a freshly scaffolded Backstage app. To setup, follow the [Prometheus metrics tutorial](https://github.com/backstage/backstage/blob/6f7eb97c755224bca1915050c4505d4d4a7ed60a/contrib/docs/tutorials/prometheus-metrics.md).
+    # <br /> Note that the /metrics endpoint is NOT present in a freshly scaffolded Backstage app. To setup, follow the [Prometheus metrics tutorial](https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/prometheus-metrics.md).
     path: /metrics

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -309,17 +309,26 @@ serviceAccount:
   # -- Auto-mount the service account token in the pod
   automountServiceAccountToken: true
 
-# ServiceMonitor configuration
-serviceMonitor:
-  # -- If enabled, ServiceMonitor resources for Prometheus Operator are created
-  enabled: false
-  # -- Namespace selector for ServiceMonitor resources
-  namespaceSelector: {}
-  # -- ServiceMonitor annotations
-  annotations: {}
-  # -- Additional ServiceMonitor labels
-  labels: {}
-  # -- ServiceMonitor scrape interval
-  interval: null
-  # -- ServiceMonitor endpoint path
-  path: /metrics
+# -- Metrics configuration
+metrics:
+
+  # -- ServiceMonitor configuration
+  # <br /> Allows configuring your backstage instance as a scrape target for [Prometheus](https://github.com/prometheus/prometheus) using a ServiceMonitor custom resource that [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) can understand.
+  serviceMonitor:
+
+    # -- If enabled, a ServiceMonitor resource for Prometheus Operator is created
+    # <br /> Prometheus Operator must be installed in your cluster prior to enabling.
+    enabled: false
+
+    # -- ServiceMonitor annotations
+    annotations: {}
+
+    # -- Additional ServiceMonitor labels
+    labels: {}
+
+    # -- ServiceMonitor scrape interval
+    interval: null
+
+    # -- ServiceMonitor endpoint path
+    # <br /> Note that the /metrics endpoint is NOT present in a freshly scaffolded Backstage app. To setup, follow the [Prometheus metrics tutorial](https://github.com/backstage/backstage/blob/6f7eb97c755224bca1915050c4505d4d4a7ed60a/contrib/docs/tutorials/prometheus-metrics.md).
+    path: /metrics


### PR DESCRIPTION
## Description of the change

Backstage instances with the [Prometheus /metrics endpoint](https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/prometheus-metrics.md) configured can set `metrics.serviceMonitor.enabled` to allow prometheus to scrape it's metrics

Disabled by default.

Example diff:
```diff
backstage, backstage, ServiceMonitor (monitoring.coreos.com) has been added:
+ # Source: backstage/templates/servicemonitor.yaml
+ apiVersion: monitoring.coreos.com/v1
+ kind: ServiceMonitor
+ metadata:
+   name: backstage
+   namespace: "backstage"
+   labels:
+     app.kubernetes.io/name: backstage
+     helm.sh/chart: backstage-0.16.0
+     app.kubernetes.io/instance: backstage
+     app.kubernetes.io/managed-by: Helm
+     app.kubernetes.io/component: backstage
+ spec:
+   namespaceSelector:
+     matchNames:
+       - "backstage"
+   selector:
+     matchLabels:
+       app.kubernetes.io/name: backstage
+       helm.sh/chart: backstage-0.16.0
+       app.kubernetes.io/instance: backstage
+       app.kubernetes.io/managed-by: Helm
+       app.kubernetes.io/component: backstage
+   endpoints:
+   - port: http-backend
+     path: /metrics
```

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
