### PR TITLE
feat: Change Service port name from hardcoded to a value

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.17.1
+version: 0.18.0
 
 dependencies:
   - name: common

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # Backstage Helm Chart
 
-![Version: 0.17.1](https://img.shields.io/badge/Version-0.17.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
 
@@ -161,7 +161,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | service.loadBalancerIP | Backstage service Load Balancer IP  <br /> Ref: https://kubernetes.io/docs/user-guide/services/#type-loadbalancer | string | `""` |
 | service.loadBalancerSourceRanges | Load Balancer sources  <br /> Ref: https://kubernetes.io/docs/tasks/access-application-cluster/cnfigure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service <br /> E.g `loadBalancerSourceRanges: [10.10.10.0/24]` | list | `[]` |
 | service.nodePorts | Node port for the Backstage client connections Choose port between `30000-32767` | object | `{"backend":""}` |
-| service.ports | Backstage svc port for client connections | object | `{"backend":7007,"targetPort":"backend"}` |
+| service.ports | Backstage svc port for client connections | object | `{"backend":7007,"name":"http-backend","targetPort":"backend"}` |
+| service.ports.name | Backstage svc port name | string | `"http-backend"` |
 | service.ports.targetPort | Backstage svc target port referencing receiving pod container port | string | `"backend"` |
 | service.sessionAffinity | Control where client requests go, to the same pod or round-robin (values: `ClientIP` or `None`) <br /> Ref: https://kubernetes.io/docs/user-guide/services/ | string | `"None"` |
 | service.type | Kubernetes Service type | string | `"ClusterIP"` |

--- a/charts/backstage/templates/service.yaml
+++ b/charts/backstage/templates/service.yaml
@@ -35,7 +35,7 @@ spec:
   sessionAffinity: {{ .Values.service.sessionAffinity }}
   {{- end }}
   ports:
-    - name: http-backend
+    - name: {{ .Values.service.ports.name }}
       port: {{ .Values.service.ports.backend }}
       targetPort: {{ .Values.service.ports.targetPort }}
       protocol: TCP

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -195,6 +195,9 @@ service:
   ports:
     backend: 7007
 
+    # -- Backstage svc port name
+    name: http-backend
+
     # -- Backstage svc target port referencing receiving pod container port
     targetPort: backend
 


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

A small PR enabling `Service`'s port name to be configured through `values.yaml`. Default value matches the previously hardcoded name.

## Existing or Associated Issue(s)

N/A

## Additional Information

N/A

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
