### PR TITLE
bugfix: Render globally configured image pull secrets in deployment template

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.17.0
+version: 0.17.1
 
 dependencies:
   - name: common

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # Backstage Helm Chart
 
-![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.17.1](https://img.shields.io/badge/Version-0.17.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
 

--- a/charts/backstage/templates/_helpers.tpl
+++ b/charts/backstage/templates/_helpers.tpl
@@ -6,6 +6,13 @@ Return the proper image name
 {{- end -}}
 
 {{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "backstage.renderImagePullSecrets" -}}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.backstage.image) "context" $) -}}
+{{- end -}}
+
+{{/*
  Create the name of the service account to use
  */}}
 {{- define "backstage.serviceAccountName" -}}

--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -56,12 +56,7 @@ spec:
           configMap:
             name: backstage-app-config
         {{- end }}
-      {{- if .Values.backstage.image.pullSecrets }}
-      imagePullSecrets:
-      {{- range .Values.backstage.image.pullSecrets }}
-          - name: {{ . }}
-      {{- end }}
-      {{- end }}
+      {{- include "backstage.renderImagePullSecrets" . | nindent 6 }}
       {{- if .Values.backstage.initContainers }}
       initContainers:
         {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.initContainers "context" $) | nindent 8 }}


### PR DESCRIPTION
## Description of the bug

When using the `global` config in the `values.yaml` to configure a (proxy) registry and the necessary image pull secret, the registry is used in the `deployment.yaml` template, but the image pull secret is not. This leads to a failing deployment, because the image cannot be pulled. 

## Description of the change

Render the image pull secret from the global config in the deployment in addition to the secret configured there explicitly.

## Existing or Associated Issue(s)

None

## Additional Information

Bitnamis `common` chart provides a helper `common.images.renderPullSecrets`:

https://github.com/bitnami/charts/blob/f13df7b00f38e5fce67eab7a1b78afb0b064344e/bitnami/common/templates/_images.tpl#L54-L80

## Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [X] JSON Schema generated.
- [X] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
