### PR TITLE
chore(ci): Fix cosign confirmation prompts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
             file_name=${chart##*/}
             chart_name=${file_name%-*}
             digest=$(awk -F "[, ]+" '/Digest/{print $NF}' < helm-push-output.log)
-            cosign sign "ghcr.io/${GITHUB_REPOSITORY}/${chart_name}@${digest}"
+            cosign sign -y "ghcr.io/${GITHUB_REPOSITORY}/${chart_name}@${digest}"
           done
         env:
           COSIGN_EXPERIMENTAL: 1


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

https://github.com/backstage/charts/pull/61 Probably introduces a bug to our CI. `cosign` now promts for confirmation which breaks our release pipeline (see https://github.com/backstage/charts/actions/runs/4404080373/jobs/7713244708 )

This should be fixed by adding a [`--yes|-y`](https://github.com/sigstore/cosign/blob/3238ae9dd7289659bc3dbe36d9372faafb59990f/doc/cosign_sign.md?plain=1#L100) param to `cosign sign` command.

## Existing or Associated Issue(s)

N/A

## Additional Information

N/A

## Checklist

Doesn't apply

- [x] ~Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).~
- [x] ~Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.~
- [x] ~JSON Schema generated.~
- [x] ~List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.~
