### PR TITLE
feat: support external postgresql configuration

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.21.0
+version: 0.21.1
 
 dependencies:
   - name: common

--- a/charts/backstage/templates/app-config-configmap.yaml
+++ b/charts/backstage/templates/app-config-configmap.yaml
@@ -2,7 +2,16 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: backstage-app-config
+  name: {{ include "backstage.appConfigName" . | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{ include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
 data:
   app-config.yaml: |
     {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.appConfig "context" $) | nindent 4 }}

--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -1,12 +1,12 @@
 {{- $imageRepository := .Values.backstage.image.repository | required "The repository name of the image is required (e.g. my-backstage:tag | docker.io/my-backstage:tag) !" -}}
 {{- $imageTag := .Values.backstage.image.tag | required "The image tag is required (e.g my-backstage:tag | docker.io/my-backstage:tag) !" -}}
-{{- $installDir := .Values.backstage.installDir -}}
+{{- $installDir := .Values.backstage.installDir | trimSuffix "/" -}}
 ---
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{ include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: backstage
     {{- if .Values.commonLabels }}
@@ -50,9 +50,9 @@ spec:
       volumes:
         {{- if (or .Values.backstage.extraAppConfig (and .Values.backstage.extraVolumeMounts .Values.backstage.extraVolumes)) }}
         {{- range .Values.backstage.extraAppConfig }}
-        - name: {{ .configMapRef }}
+        - name: {{ required `property "backstage.extraAppConfig[].configMapRef" must be set` .configMapRef | quote }}
           configMap:
-            name: {{ .configMapRef }}
+            name: {{ .configMapRef | quote }}
         {{- end }}
         {{- if .Values.backstage.extraVolumes }}
           {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.extraVolumes "context" $ ) | nindent 8 }}
@@ -61,7 +61,7 @@ spec:
         {{- if .Values.backstage.appConfig }}
         - name: backstage-app-config
           configMap:
-            name: backstage-app-config
+            name: {{ include "backstage.appConfigName" . | quote }}
         {{- end }}
       {{- include "backstage.renderImagePullSecrets" . | nindent 6 }}
       {{- if .Values.backstage.initContainers }}
@@ -92,12 +92,12 @@ spec:
           {{- if .Values.backstage.extraAppConfig }}
           {{- range .Values.backstage.extraAppConfig }}
             - "--config"
-            - "{{ $installDir }}/{{ .filename }}"
+            - {{ printf "%s/%s" $installDir .filename | quote }}
           {{- end }}
           {{- end }}
           {{- if .Values.backstage.appConfig }}
             - "--config"
-            - "{{ $installDir }}/app-config-from-configmap.yaml"
+            - {{ printf "%s/app-config-from-configmap.yaml" $installDir | quote }}
           {{- end }}
           {{- end }}
           {{- if .Values.backstage.resources }}
@@ -113,13 +113,13 @@ spec:
           env:
             - name: APP_CONFIG_backend_listen_port
               value: {{ .Values.backstage.containerPorts.backend | quote }}
-            {{- if .Values.postgresql.enabled }}
+            {{- if or .Values.postgresql.enabled .Values.externalPostgresql.enabled }}
             - name: POSTGRES_HOST
-              value: {{ include "backstage.postgresql.host" . }}
+              value: {{ include "backstage.postgresql.host" . | quote }}
             - name: POSTGRES_PORT
-              value: "5432"
+              value: {{ include "backstage.postgresql.port" . | quote }}
             - name: POSTGRES_USER
-              value: {{ .Values.postgresql.auth.username }}
+              value: {{ include "backstage.postgresql.username" . | quote }}
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -136,13 +136,13 @@ spec:
           {{- if (or .Values.backstage.extraAppConfig .Values.backstage.appConfig (and .Values.backstage.extraVolumeMounts .Values.backstage.extraVolumes)) }}
           volumeMounts:
             {{- range .Values.backstage.extraAppConfig }}
-            - name: {{ .configMapRef }}
-              mountPath: "{{ $installDir }}/{{ .filename }}"
-              subPath: {{ .filename }}
+            - name: {{ .configMapRef | quote }}
+              mountPath: {{ printf "%s/%s" $installDir .filename | quote }}
+              subPath: {{ required (printf `property "backstage.extraAppConfig[@configMapRef='%s'].filename" must be set` .configMapRef) .filename | quote }}
             {{- end }}
             {{- if .Values.backstage.appConfig }}
             - name: backstage-app-config
-              mountPath: "{{ $installDir }}/app-config-from-configmap.yaml"
+              mountPath: {{ printf "%s/app-config-from-configmap.yaml" $installDir | quote }}
               subPath: app-config.yaml
             {{- end }}
             {{- if .Values.backstage.extraVolumeMounts }}

--- a/charts/backstage/templates/ingress.yaml
+++ b/charts/backstage/templates/ingress.yaml
@@ -1,9 +1,10 @@
 {{- if .Values.ingress.enabled }}
+{{- $host := required `property "ingress.host" must be set` .Values.ingress.host }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: backstage
     {{- if .Values.commonLabels }}
@@ -23,11 +24,11 @@ spec:
   {{- if .Values.ingress.tls.enabled }}
   tls:
     - hosts:
-      - {{ .Values.ingress.host }}
-      secretName: {{ .Values.ingress.tls.secretName }}
+      - {{ $host | quote }}
+      secretName: {{ required `property "ingress.tls.secretName" must be set` .Values.ingress.tls.secretName }}
   {{- end }}
   rules:
-    - host: {{ .Values.ingress.host }}
+    - host: {{ $host | quote }}
       http:
         paths:
           - path: /
@@ -36,5 +37,5 @@ spec:
               service:
                 name: {{ include "common.names.fullname" . }}
                 port:
-                  number: {{ .Values.service.ports.backend }}
+                  name: {{ .Values.service.ports.name }}
 {{- end }}

--- a/charts/backstage/templates/service.yaml
+++ b/charts/backstage/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }} 
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: backstage
     {{- if .Values.commonLabels }}

--- a/charts/backstage/templates/serviceaccount.yaml
+++ b/charts/backstage/templates/serviceaccount.yaml
@@ -3,16 +3,16 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "backstage.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
-  labels:
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: backstage
     {{- with .Values.serviceAccount.labels }}
-    {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | trim | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.serviceAccount.annotations }}
   annotations:
     {{- with .Values.serviceAccount.annotations }}
-    {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | trim | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}

--- a/charts/backstage/templates/servicemonitor.yaml
+++ b/charts/backstage/templates/servicemonitor.yaml
@@ -2,8 +2,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "common.names.fullname" $ }}
-  namespace: {{ .Release.Namespace | quote }}
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if or .Values.commonAnnotations .Values.metrics.serviceMonitor.annotations  }}
   annotations:
     {{- if $.Values.commonAnnotations }}
@@ -13,7 +13,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.annotations "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
-  labels: {{ include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: backstage
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -24,14 +24,23 @@ metadata:
 spec:
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace | quote }}
+      - {{ include "common.names.namespace" . | quote }}
   selector:
-    matchLabels: {{ include "common.labels.standard" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: backstage
   endpoints:
   - port: http-backend
     path: {{ .Values.metrics.serviceMonitor.path }}
     {{- with .Values.metrics.serviceMonitor.interval }}
     interval: {{ . }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.relabelings }}
+    relabelings: {{- include "common.tplvalues.render" ( dict "value" . "context" $) | nindent 6 }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{- include "common.tplvalues.render" ( dict "value" . "context" $) | nindent 6 }}
     {{- end }}
 {{- end -}}

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -271,6 +271,26 @@ networkPolicy:
     #             label: example
     customRules: []
 
+# -- External PostgreSQL Server Configuration.
+externalPostgresql:
+
+  # -- Switch to enable or disable the external PostgreSQL Server Configuration.
+  enabled: false
+
+  # -- External PostgreSQL Server Hostname.
+  host: ~
+
+  # -- External PostgreSQL Server Port.
+  port: 5432
+
+  # -- External PostgreSQL Server Username.
+  username: ~
+
+  # -- Kubernetes Secret Name that contains password for External PostgreSQL Server.
+  passwordSecret: ~
+
+  # -- Key in the Kubernetes Secret Name with PostgreSQL Server password.
+  passwordSecretKey: password
 
 # -- PostgreSQL [chart configuration](https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml)
 # @default -- See below
@@ -346,6 +366,15 @@ metrics:
     # -- ServiceMonitor scrape interval
     interval: null
 
+    # -- ServiceMonitor scrape timeout
+    scrapeTimeout: null
+
     # -- ServiceMonitor endpoint path
     # <br /> Note that the /metrics endpoint is NOT present in a freshly scaffolded Backstage app. To setup, follow the [Prometheus metrics tutorial](https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/prometheus-metrics.md).
     path: /metrics
+
+    # -- ServiceMonitor relabelings
+    relabelings: []
+
+    # -- ServiceMonitor metric relabelings
+    metricRelabelings: []


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

* Support external PostgreSQL server configuration.
* Use bitnami's template "common.names.namespace" for namespace configuration in manifests.
* Fix missing properties (namespace, labels, annotations) in the "backstage-app-config" config map.
* Add assertions for ingress hostname and TLS config.
* Add missing standard labels in ServiceAccount.
* Support "scrapeTimeout", "relabelings" and "metricRelabelings" configurations in ServiceMonitor.
* Use "common.labels.matchLabels" instead of "common.labels.standard" in ServiceMonitor selector section

## Existing or Associated Issue(s)

None.

## Additional Information

None.

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
