### PR TITLE
feat: support ServiceMonitor extra config

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.21.0
+version: 0.22.0
 
 dependencies:
   - name: common

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # Backstage Helm Chart
 
-![Version: 0.21.0](https://img.shields.io/badge/Version-0.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.22.0](https://img.shields.io/badge/Version-0.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
 
@@ -133,13 +133,16 @@ The command removes all the Kubernetes components associated with the chart and 
 | ingress.tls.enabled | Enable TLS configuration for the host defined at `ingress.host` parameter | bool | `false` |
 | ingress.tls.secretName | The name to which the TLS Secret will be called | string | `""` |
 | kubeVersion | Override Kubernetes version | string | `""` |
-| metrics | Metrics configuration | object | `{"serviceMonitor":{"annotations":{},"enabled":false,"interval":null,"labels":{},"path":"/metrics"}}` |
-| metrics.serviceMonitor | ServiceMonitor configuration <br /> Allows configuring your backstage instance as a scrape target for [Prometheus](https://github.com/prometheus/prometheus) using a ServiceMonitor custom resource that [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) can understand. | object | `{"annotations":{},"enabled":false,"interval":null,"labels":{},"path":"/metrics"}` |
+| metrics | Metrics configuration | object | `{"serviceMonitor":{"annotations":{},"enabled":false,"interval":null,"labels":{},"metricRelabelings":[],"path":"/metrics","relabelings":[],"scrapeTimeout":null}}` |
+| metrics.serviceMonitor | ServiceMonitor configuration <br /> Allows configuring your backstage instance as a scrape target for [Prometheus](https://github.com/prometheus/prometheus) using a ServiceMonitor custom resource that [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) can understand. | object | `{"annotations":{},"enabled":false,"interval":null,"labels":{},"metricRelabelings":[],"path":"/metrics","relabelings":[],"scrapeTimeout":null}` |
 | metrics.serviceMonitor.annotations | ServiceMonitor annotations | object | `{}` |
 | metrics.serviceMonitor.enabled | If enabled, a ServiceMonitor resource for Prometheus Operator is created <br /> Prometheus Operator must be installed in your cluster prior to enabling. | bool | `false` |
 | metrics.serviceMonitor.interval | ServiceMonitor scrape interval | string | `nil` |
 | metrics.serviceMonitor.labels | Additional ServiceMonitor labels | object | `{}` |
+| metrics.serviceMonitor.metricRelabelings | ServiceMonitor metric relabelings | list | `[]` |
 | metrics.serviceMonitor.path | ServiceMonitor endpoint path <br /> Note that the /metrics endpoint is NOT present in a freshly scaffolded Backstage app. To setup, follow the [Prometheus metrics tutorial](https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/prometheus-metrics.md). | string | `"/metrics"` |
+| metrics.serviceMonitor.relabelings | ServiceMonitor relabelings | list | `[]` |
+| metrics.serviceMonitor.scrapeTimeout | ServiceMonitor scrape timeout | string | `nil` |
 | nameOverride | String to partially override common.names.fullname | string | `""` |
 | networkPolicy | Network policies <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/ | object | `{"egressRules":{"customRules":[]},"enabled":false,"externalAccess":{"from":[]}}` |
 | networkPolicy.egressRules | Custom network policy rule | object | `{"customRules":[]}` |

--- a/charts/backstage/ci/serviceMonitorRelabelings-values.yaml
+++ b/charts/backstage/ci/serviceMonitorRelabelings-values.yaml
@@ -1,0 +1,13 @@
+metrics:
+  serviceMonitor:
+    interval: 30s
+    scrapeTimeout: 10s
+    relabelings:
+      - action: labeldrop
+        regex: "^(test)$"
+    metricRelabelings:
+      - action: labeldrop
+        regex: "^(endpoint|instance)$"
+      - action: replace
+        targetLabel: job
+        replacement: '{{ include "common.names.fullname" . }}'

--- a/charts/backstage/templates/servicemonitor.yaml
+++ b/charts/backstage/templates/servicemonitor.yaml
@@ -29,9 +29,18 @@ spec:
     matchLabels: {{ include "common.labels.standard" . | nindent 6 }}
       app.kubernetes.io/component: backstage
   endpoints:
-  - port: http-backend
+  - port: {{ .Values.service.ports.name }}
     path: {{ .Values.metrics.serviceMonitor.path }}
     {{- with .Values.metrics.serviceMonitor.interval }}
     interval: {{ . }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.relabelings }}
+    relabelings: {{- include "common.tplvalues.render" ( dict "value" . "context" $) | nindent 6 }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{- include "common.tplvalues.render" ( dict "value" . "context" $) | nindent 6 }}
     {{- end }}
 {{- end -}}

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -346,6 +346,15 @@ metrics:
     # -- ServiceMonitor scrape interval
     interval: null
 
+    # -- ServiceMonitor scrape timeout
+    scrapeTimeout: null
+
     # -- ServiceMonitor endpoint path
     # <br /> Note that the /metrics endpoint is NOT present in a freshly scaffolded Backstage app. To setup, follow the [Prometheus metrics tutorial](https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/prometheus-metrics.md).
     path: /metrics
+
+    # -- ServiceMonitor relabelings
+    relabelings: []
+
+    # -- ServiceMonitor metric relabelings
+    metricRelabelings: []


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

This PR adds extra configuration of the Prometheus Service monitor, such as:
* Relabelings
* MetricRelabelings
* ScrapeTimeout

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
