### PR TITLE
feat: support external postgresql configuration

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.21.0
+version: 0.22.0
 
 dependencies:
   - name: common

--- a/charts/backstage/ci/externalPostgres-values.yaml
+++ b/charts/backstage/ci/externalPostgres-values.yaml
@@ -1,0 +1,6 @@
+externalPostgresql:
+  enabled: true
+  host: backstage-postgresql
+  username: backstage
+  passwordSecret: backstage-postgresql
+  passwordSecretKey: password

--- a/charts/backstage/templates/_helpers.tpl
+++ b/charts/backstage/templates/_helpers.tpl
@@ -35,10 +35,36 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Return the Postgres Database hostname
 */}}
 {{- define "backstage.postgresql.host" -}}
-{{- if eq .Values.postgresql.architecture "replication" }}
-{{- include "backstage.postgresql.fullname" . -}}-primary
-{{- else -}}
-{{- include "backstage.postgresql.fullname" . -}}
+{{- if .Values.postgresql.enabled -}}
+    {{- if eq .Values.postgresql.architecture "replication" }}
+        {{- include "backstage.postgresql.fullname" . -}}-primary
+    {{- else -}}
+        {{- include "backstage.postgresql.fullname" . -}}
+    {{- end -}}
+{{- else if .Values.externalPostgresql.enabled -}}
+    {{- required `property "externalPostgresql.host" must be set` .Values.externalPostgresql.host  -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the Postgres Database port
+*/}}
+{{- define "backstage.postgresql.port" -}}
+{{- if .Values.postgresql.enabled -}}
+    {{- default 5432 .Values.postgresql.containerPorts.postgresql -}}
+{{- else if .Values.externalPostgresql.enabled -}}
+    {{- default 5432 .Values.externalPostgresql.port  -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the Postgres Database Username
+*/}}
+{{- define "backstage.postgresql.username" -}}
+{{- if .Values.postgresql.enabled -}}
+    {{- default "backstage" .Values.postgresql.auth.username -}}
+{{- else if .Values.externalPostgresql.enabled -}}
+    {{- default "backstage" .Values.externalPostgresql.username  -}}
 {{- end -}}
 {{- end -}}
 
@@ -46,10 +72,14 @@ Return the Postgres Database hostname
 Return the Postgres Database Secret Name
 */}}
 {{- define "backstage.postgresql.databaseSecretName" -}}
-{{- if .Values.postgresql.auth.existingSecret }}
-    {{- tpl .Values.postgresql.auth.existingSecret $ -}}
-{{- else -}}
-    {{- default (include "backstage.postgresql.fullname" .) (tpl .Values.postgresql.auth.existingSecret $) -}}
+{{- if .Values.postgresql.enabled }}
+    {{- if .Values.postgresql.auth.existingSecret }}
+        {{- tpl .Values.postgresql.auth.existingSecret $ -}}
+    {{- else -}}
+        {{- include "backstage.postgresql.fullname" . -}}
+    {{- end -}}
+{{- else if .Values.externalPostgresql.enabled -}}
+    {{- required `property "externalPostgresql.passwordSecret" must be set` .Values.externalPostgresql.passwordSecret -}}
 {{- end -}}
 {{- end -}}
 
@@ -57,9 +87,13 @@ Return the Postgres Database Secret Name
 Return the Postgres databaseSecret key to retrieve credentials for database
 */}}
 {{- define "backstage.postgresql.databaseSecretKey" -}}
-{{- if .Values.postgresql.auth.existingSecret -}}
-    {{- .Values.postgresql.auth.secretKeys.userPasswordKey  -}}
-{{- else -}}
-    {{- print "password" -}}
+{{- if .Values.postgresql.enabled }}
+    {{- if .Values.postgresql.auth.existingSecret -}}
+        {{- .Values.postgresql.auth.secretKeys.userPasswordKey  -}}
+    {{- else -}}
+        {{- "password" -}}
+    {{- end -}}
+{{- else if .Values.externalPostgresql.enabled -}}
+    {{- default "password" .Values.externalPostgresql.passwordSecretKey -}}
 {{- end -}}
 {{- end -}}

--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -113,13 +113,13 @@ spec:
           env:
             - name: APP_CONFIG_backend_listen_port
               value: {{ .Values.backstage.containerPorts.backend | quote }}
-            {{- if .Values.postgresql.enabled }}
+            {{- if or .Values.postgresql.enabled .Values.externalPostgresql.enabled }}
             - name: POSTGRES_HOST
-              value: {{ include "backstage.postgresql.host" . }}
+              value: {{ include "backstage.postgresql.host" . | quote }}
             - name: POSTGRES_PORT
-              value: "5432"
+              value: {{ include "backstage.postgresql.port" . | quote }}
             - name: POSTGRES_USER
-              value: {{ .Values.postgresql.auth.username }}
+              value: {{ include "backstage.postgresql.username" . | quote }}
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -271,6 +271,26 @@ networkPolicy:
     #             label: example
     customRules: []
 
+# -- External PostgreSQL Server Configuration.
+externalPostgresql:
+
+  # -- Switch to enable or disable the external PostgreSQL Server Configuration.
+  enabled: false
+
+  # -- External PostgreSQL Server Hostname.
+  host: ~
+
+  # -- External PostgreSQL Server Port.
+  port: 5432
+
+  # -- External PostgreSQL Server Username.
+  username: ~
+
+  # -- Kubernetes Secret Name that contains password for External PostgreSQL Server.
+  passwordSecret: ~
+
+  # -- Key in the Kubernetes Secret Name with PostgreSQL Server password.
+  passwordSecretKey: password
 
 # -- PostgreSQL [chart configuration](https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml)
 # @default -- See below


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

This PR adds support to the External PostgreSQL Server configuration.

**NOTE**: the Bitnami PostgreSQL Helm chart is a priority over the External PostgreSQL configuration.disable 

Usage example:

```yaml
postgresql:
  enabled: false

externalPostgresql:
  enabled: true
  host: backstage-postgresql
  username: backstage
  passwordSecret: backstage-postgresql
  passwordSecretKey: password
```

## Existing or Associated Issue(s)

None

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
