### PR TITLE
feat: support "affinity" and "topologySpreadConstraints" configurations

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.21.0
+version: 0.22.0
 
 dependencies:
   - name: common

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # Backstage Helm Chart
 
-![Version: 0.21.0](https://img.shields.io/badge/Version-0.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.22.0](https://img.shields.io/badge/Version-0.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
 
@@ -86,6 +86,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Key | Description | Type | Default |
 |-----|-------------|------|---------|
 | backstage | Backstage parameters | object | See below |
+| backstage.affinity | Affinity for pod assignment <br /> Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity <br /> Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set  | object | `{}` |
 | backstage.annotations | Additional custom annotations for the `Deployment` resource | object | `{}` |
 | backstage.appConfig | Generates ConfigMap and configures it in the Backstage pods | object | `{}` |
 | backstage.args | Backstage container command arguments | list | `[]` |
@@ -106,12 +107,19 @@ The command removes all the Kubernetes components associated with the chart and 
 | backstage.image.tag | Backstage image tag (immutable tags are recommended) | string | `"latest"` |
 | backstage.initContainers | Backstage container init containers | list | `[]` |
 | backstage.installDir | Directory containing the backstage installation | string | `"/app"` |
+| backstage.nodeAffinityPreset | Node affinity preset <br /> Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity | object | `{"key":"","type":"","values":[]}` |
+| backstage.nodeAffinityPreset.key | Node label key to match Ignored if `affinity` is set. <!-- E.g. key: "kubernetes.io/e2e-az-name" --> | string | `""` |
+| backstage.nodeAffinityPreset.type | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | string | `""` |
+| backstage.nodeAffinityPreset.values | Node label values to match. Ignored if `affinity` is set. <!-- E.g. values:   - e2e-az1   - e2e-az2 --> | list | `[]` |
 | backstage.nodeSelector | Node labels for pod assignment <br /> Ref: https://kubernetes.io/docs/user-guide/node-selection/ | object | `{}` |
+| backstage.podAffinityPreset | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard` <br /> Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity | string | `""` |
 | backstage.podAnnotations | Annotations to add to the backend deployment pods | object | `{}` |
+| backstage.podAntiAffinityPreset | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard` <br /> Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity | string | `""` |
 | backstage.podSecurityContext | Security settings for a Pod.  The security settings that you specify for a Pod apply to all Containers in the Pod. <br /> Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod | object | `{}` |
 | backstage.replicas | Number of deployment replicas | int | `1` |
 | backstage.resources | Resource requests/limits <br /> Ref: https://kubernetes.io/docs/user-guide/compute-resources/ <!-- E.g. resources:   limits:     memory: 1Gi     cpu: 1000m   requests:     memory: 250Mi     cpu: 100m --> | object | `{}` |
 | backstage.tolerations | Node tolerations for server scheduling to nodes with taints <br /> Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ | list | `[]` |
+| backstage.topologySpreadConstraints | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template <br /> Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods  | list | `[]` |
 | clusterDomain | Default Kubernetes cluster domain | string | `"cluster.local"` |
 | commonAnnotations | Annotations to add to all deployed objects | object | `{}` |
 | commonLabels | Labels to add to all deployed objects | object | `{}` |

--- a/charts/backstage/ci/affinitiesPresets-values.yaml
+++ b/charts/backstage/ci/affinitiesPresets-values.yaml
@@ -1,0 +1,8 @@
+backstage:
+  podAffinityPreset: soft
+  podAntiAffinityPreset: soft
+  nodeAffinityPreset:
+    type: hard
+    key: kubernetes.io/os
+    values:
+      - linux

--- a/charts/backstage/ci/affinity-values.yaml
+++ b/charts/backstage/ci/affinity-values.yaml
@@ -1,0 +1,18 @@
+backstage:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                  - linux
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: backstage
+          weight: 1

--- a/charts/backstage/ci/affinityString-values.yaml
+++ b/charts/backstage/ci/affinityString-values.yaml
@@ -1,0 +1,21 @@
+backstage:
+  affinity: |-
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                  - linux
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            topologyKey: kubernetes.io/hostname
+            namespaces:
+              - {{ include "common.names.namespace" . | quote }}
+            labelSelector:
+              matchLabels:
+                {{- include "common.labels.matchLabels" . | nindent 12 }}
+                app.kubernetes.io/component: backstage
+          weight: 1

--- a/charts/backstage/ci/topologySpreadConstraints-values.yaml
+++ b/charts/backstage/ci/topologySpreadConstraints-values.yaml
@@ -1,0 +1,8 @@
+backstage:
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: backstage

--- a/charts/backstage/ci/topologySpreadConstraintsString-values.yaml
+++ b/charts/backstage/ci/topologySpreadConstraintsString-values.yaml
@@ -1,0 +1,9 @@
+backstage:
+  topologySpreadConstraints: |-
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          {{- include "common.labels.matchLabels" . | nindent 6 }}
+          app.kubernetes.io/component: backstage

--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -39,6 +39,22 @@ spec:
       securityContext:
         {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.backstage.affinity }}
+      affinity:
+        {{- include "common.tplvalues.render" (dict "value" .Values.backstage.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity:
+          {{- include "common.affinities.pods" (dict "type" .Values.backstage.podAffinityPreset "component" "backstage" "context" $) | nindent 10 }}
+        podAntiAffinity:
+          {{- include "common.affinities.pods" (dict "type" .Values.backstage.podAntiAffinityPreset "component" "backstage" "context" $) | nindent 10 }}
+        nodeAffinity:
+          {{- include "common.affinities.nodes" (dict "type" .Values.backstage.nodeAffinityPreset.type "key" .Values.backstage.nodeAffinityPreset.key "values" .Values.backstage.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.backstage.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- include "common.tplvalues.render" (dict "value" .Values.backstage.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
       {{- if .Values.backstage.nodeSelector }}
       nodeSelector:
         {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.nodeSelector "context" $) | nindent 8 }}

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -191,6 +191,44 @@ backstage:
   # -- Additional custom annotations for the `Deployment` resource
   annotations: {}
 
+  # -- Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  # <br /> Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  podAffinityPreset: ""
+
+  # -- Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  # <br /> Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  podAntiAffinityPreset: ""
+
+  # -- Node affinity preset
+  # <br /> Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  nodeAffinityPreset:
+
+    # -- Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+    type: ""
+
+    # -- Node label key to match Ignored if `affinity` is set.
+    # <!-- E.g.
+    # key: "kubernetes.io/e2e-az-name" -->
+    key: ""
+
+    # -- Node label values to match. Ignored if `affinity` is set.
+    # <!-- E.g.
+    # values:
+    #   - e2e-az1
+    #   - e2e-az2 -->
+    values: []
+
+  # -- Affinity for pod assignment
+  # <br /> Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  # <br /> Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
+  #
+  affinity: {}
+
+  # -- Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
+  # <br /> Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+  #
+  topologySpreadConstraints: []
+
 ## @section Traffic Exposure parameters
 
 ## Service parameters


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

This PR supports configuring [Pod Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) and [Pod TopologySpreadConstraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/).

## Existing or Associated Issue(s)

None

## Additional Information

None

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
