### PR TITLE
feat: add json schema for the chart

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -1,22 +1,15 @@
+annotations:
+  artifacthub.io/category: integration-delivery
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: support
+      url: https://github.com/backstage/charts/issues
+    - name: Chart Source
+      url: https://github.com/backstage/charts
+    - name: Default Image Source
+      url: https://github.com/backstage/backstage
 apiVersion: v2
-name: backstage
 description: A Helm chart for deploying a Backstage application
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
-type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.22.0
-
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -27,3 +20,21 @@ dependencies:
     name: postgresql
     repository: https://charts.bitnami.com/bitnami
     version: 11.x.x
+home: https://backstage.io
+icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/backstage/icon/color/backstage-icon-color.svg
+keywords:
+  - backstage
+  - idp
+maintainers:
+  - name: Backstage
+    url: https://backstage.io
+name: backstage
+type: application
+sources:
+- https://github.com/backstage/charts
+- https://github.com/backstage/backstage
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.22.0

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.21.1
+version: 0.22.0
 
 dependencies:
   - name: common

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # Backstage Helm Chart
 
-![Version: 0.21.1](https://img.shields.io/badge/Version-0.21.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.22.0](https://img.shields.io/badge/Version-0.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
 
@@ -99,19 +99,19 @@ The command removes all the Kubernetes components associated with the chart and 
 | backstage.extraVolumeMounts | Backstage container additional volume mounts | list | `[]` |
 | backstage.extraVolumes | Backstage container additional volumes | list | `[]` |
 | backstage.image.debug | Set to true if you would like to see extra information on logs | bool | `false` |
-| backstage.image.pullPolicy | Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent' <br /> Ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images | string | `"Always"` |
+| backstage.image.pullPolicy | Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent' <br /> Ref: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy | string | `"Always"` |
 | backstage.image.pullSecrets | Optionally specify an array of imagePullSecrets.  Secrets must be manually created in the namespace. <br /> Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ <br /> E.g: `pullSecrets: [myRegistryKeySecretName]` | list | `[]` |
 | backstage.image.registry | Backstage image registry | string | `"ghcr.io"` |
 | backstage.image.repository | Backstage image repository | string | `"backstage/backstage"` |
 | backstage.image.tag | Backstage image tag (immutable tags are recommended) | string | `"latest"` |
 | backstage.initContainers | Backstage container init containers | list | `[]` |
 | backstage.installDir | Directory containing the backstage installation | string | `"/app"` |
-| backstage.nodeSelector | Node labels for pod assignment <br /> Ref: https://kubernetes.io/docs/user-guide/node-selection/ | object | `{}` |
+| backstage.nodeSelector | Node labels for pod assignment <br /> Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector | object | `{}` |
 | backstage.podAnnotations | Annotations to add to the backend deployment pods | object | `{}` |
 | backstage.podSecurityContext | Security settings for a Pod.  The security settings that you specify for a Pod apply to all Containers in the Pod. <br /> Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod | object | `{}` |
 | backstage.replicas | Number of deployment replicas | int | `1` |
-| backstage.resources | Resource requests/limits <br /> Ref: https://kubernetes.io/docs/user-guide/compute-resources/ <!-- E.g. resources:   limits:     memory: 1Gi     cpu: 1000m   requests:     memory: 250Mi     cpu: 100m --> | object | `{}` |
-| backstage.tolerations | Node tolerations for server scheduling to nodes with taints <br /> Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ | list | `[]` |
+| backstage.resources | Resource requests/limits <br /> Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container <!-- E.g. resources:   limits:     memory: 1Gi     cpu: 1000m   requests:     memory: 250Mi     cpu: 100m --> | object | `{}` |
+| backstage.tolerations | Node tolerations for server scheduling to nodes with taints <br /> Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ | list | `[]` |
 | clusterDomain | Default Kubernetes cluster domain | string | `"cluster.local"` |
 | commonAnnotations | Annotations to add to all deployed objects | object | `{}` |
 | commonLabels | Labels to add to all deployed objects | object | `{}` |
@@ -161,13 +161,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | service.clusterIP | Backstage service Cluster IP  <br /> E.g `clusterIP: None` | string | `""` |
 | service.externalTrafficPolicy | Backstage service external traffic policy  Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip | string | `"Cluster"` |
 | service.extraPorts | Extra ports to expose in the Backstage service (normally used with the `sidecar` value) | list | `[]` |
-| service.loadBalancerIP | Backstage service Load Balancer IP  <br /> Ref: https://kubernetes.io/docs/user-guide/services/#type-loadbalancer | string | `""` |
-| service.loadBalancerSourceRanges | Load Balancer sources  <br /> Ref: https://kubernetes.io/docs/tasks/access-application-cluster/cnfigure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service <br /> E.g `loadBalancerSourceRanges: [10.10.10.0/24]` | list | `[]` |
+| service.loadBalancerIP | Backstage service Load Balancer IP  <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer | string | `""` |
+| service.loadBalancerSourceRanges | Load Balancer sources  <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer <br /> E.g `loadBalancerSourceRanges: [10.10.10.0/24]` | list | `[]` |
 | service.nodePorts | Node port for the Backstage client connections Choose port between `30000-32767` | object | `{"backend":""}` |
 | service.ports | Backstage svc port for client connections | object | `{"backend":7007,"name":"http-backend","targetPort":"backend"}` |
 | service.ports.name | Backstage svc port name | string | `"http-backend"` |
 | service.ports.targetPort | Backstage svc target port referencing receiving pod container port | string | `"backend"` |
-| service.sessionAffinity | Control where client requests go, to the same pod or round-robin (values: `ClientIP` or `None`) <br /> Ref: https://kubernetes.io/docs/user-guide/services/ | string | `"None"` |
+| service.sessionAffinity | Control where client requests go, to the same pod or round-robin (values: `ClientIP` or `None`) <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/service/#session-stickiness | string | `"None"` |
 | service.type | Kubernetes Service type | string | `"ClusterIP"` |
 | serviceAccount | Service Account Configuration | object | See below |
 | serviceAccount.annotations | Additional custom annotations for the ServiceAccount. | object | `{}` |

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -5,6 +5,19 @@
 
 A Helm chart for deploying a Backstage application
 
+**Homepage:** <https://backstage.io>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Backstage |  | <https://backstage.io> |
+
+## Source Code
+
+* <https://github.com/backstage/charts>
+* <https://github.com/backstage/backstage>
+
 ---
 
 [Backstage](https://backstage.io) is an open platform for building developer portals. Powered by a centralized software catalog, Backstage restores order to your microservices and infrastructure and enables your product teams to ship high-quality code quickly — without compromising autonomy.

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -1,0 +1,669 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Backstage chart schema",
+    "properties": {
+        "global": {
+            "title": "Global parameters.",
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "title": "Global Docker image registry",
+                    "type": "string",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "title": "Global Docker registry secret names as an array",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true,
+                    "examples": [
+                        [
+                            "myRegistryKeySecretName"
+                        ]
+                    ]
+                }
+            }
+        },
+        "kubeVersion": {
+            "title": "Override Kubernetes version",
+            "type": "string",
+            "default": ""
+        },
+        "nameOverride": {
+            "title": "String to partially override common.names.fullname",
+            "type": "string",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "title": "String to fully override common.names.fullname",
+            "type": "string",
+            "default": ""
+        },
+        "clusterDomain": {
+            "title": "Default Kubernetes cluster domain",
+            "type": "string",
+            "default": "cluster.local"
+        },
+        "commonLabels": {
+            "title": "Labels to add to all deployed objects",
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            },
+            "default": {}
+        },
+        "commonAnnotations": {
+            "title": "Annotations to add to all deployed objects",
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            },
+            "default": {}
+        },
+        "extraDeploy": {
+            "title": "Array of extra objects to deploy with the release",
+            "type": "array",
+            "default": [],
+            "items": {
+                "type": [
+                    "string",
+                    "object"
+                ]
+            },
+            "uniqueItems": true
+        },
+        "diagnosticMode": {
+            "title": "Enable diagnostic mode in the Deployment",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "title": "Enable diagnostic mode",
+                    "description": "All probes will be disabled and the command will be overridden",
+                    "type": "boolean",
+                    "default": false
+                },
+                "command": {
+                    "title": "Command to override all containers in the Deployment",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "sleep"
+                    ]
+                },
+                "args": {
+                    "title": "Args to override all containers in the Deployment",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "infinity"
+                    ]
+                }
+            }
+        },
+        "ingress": {
+            "title": "Ingress parameters",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "title": "Enable the creation of the ingress resource",
+                    "type": "boolean",
+                    "default": false
+                },
+                "className": {
+                    "title": "Name of the IngressClass cluster resource which defines which controller will implement the resource.",
+                    "type": "string",
+                    "default": "",
+                    "examples": [
+                        "nginx"
+                    ]
+                },
+                "annotations": {
+                    "title": "Additional annotations for the Ingress resource",
+                    "type": "object",
+                    "default": {},
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "host": {
+                    "title": "Hostname to be used to expose the route to access the backstage application.",
+                    "type": "string",
+                    "default": "",
+                    "examples": [
+                        "backstage.10.0.0.1.nip.io"
+                    ]
+                },
+                "tls": {
+                    "title": "Ingress TLS parameters",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "title": "Enable TLS configuration",
+                            "description": "TLS for the host defined at `ingress.host` parameter",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "secretName": {
+                            "title": "The name to which the TLS Secret will be called",
+                            "type": "string",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "backstage": {
+            "title": "Backstage parameters",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "replicas": {
+                    "title": "Number of deployment replicas",
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 1
+                },
+                "image": {
+                    "title": "Image parameters",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "registry": {
+                            "title": "Backstage image registry",
+                            "type": "string",
+                            "default": "ghcr.io",
+                            "examples": [
+                                "ghcr.io",
+                                "quay.io",
+                                "docker.io"
+                            ]
+                        },
+                        "repository": {
+                            "title": "Backstage image repository",
+                            "type": "string",
+                            "default": "backstage/backstage"
+                        },
+                        "tag": {
+                            "title": "Backstage image tag",
+                            "description": "Immutable tags are recommended.",
+                            "type": "string",
+                            "default": "latest"
+                        },
+                        "pullPolicy": {
+                            "title": "Specify a imagePullPolicy.",
+                            "description": "Ref: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy",
+                            "type": "string",
+                            "default": "Always",
+                            "enum": [
+                                "Always",
+                                "IfNotPresent"
+                            ]
+                        },
+                        "pullSecrets": {
+                            "title": "Optionally specify an array of imagePullSecrets.",
+                            "description": "Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "default": [],
+                            "examples": [
+                                "myRegistryKeySecretName"
+                            ]
+                        },
+                        "debug": {
+                            "title": "Set to true if you would like to see extra information on logs",
+                            "type": "boolean",
+                            "default": false
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "title": "Container ports on the Deployment",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "backend": {
+                            "title": "Backstage backend port.",
+                            "type": "integer",
+                            "default": 7007
+                        }
+                    }
+                },
+                "command": {
+                    "title": "Backstage container command",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "node",
+                        "packages/backend"
+                    ]
+                },
+                "args": {
+                    "title": "Backstage container command arguments",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "extraAppConfig": {
+                    "title": "Extra app configuration files to inline into command arguments",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "filename": {
+                                "type": "string"
+                            },
+                            "configMapRef": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "default": []
+                },
+                "extraContainers": {
+                    "title": "Deployment sidecars.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
+                    },
+                    "default": []
+                },
+                "extraEnvVars": {
+                    "title": "Backstage container environment variables",
+                    "type": "array",
+                    "items": {
+                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar"
+                    },
+                    "default": [],
+                    "examples": [
+                        [
+                            {
+                                "name": "APP_CONFIG_backend_cache_store",
+                                "value": "memory"
+                            }
+                        ]
+                    ]
+                },
+                "extraEnvVarsSecrets": {
+                    "title": "Backstage container environment variables from Secrets",
+                    "type": "array",
+                    "description": "Translates into array of `envFrom.[].secretRef.name`",
+                    "items": {
+                        "type": "object"
+                    },
+                    "default": [],
+                    "examples": [
+                        [
+                            "my-backstage-secrets"
+                        ]
+                    ]
+                },
+                "extraVolumeMounts": {
+                    "title": "Backstage container additional volume mounts",
+                    "type": "array",
+                    "items": {
+                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount"
+                    },
+                    "default": []
+                },
+                "extraVolumes": {
+                    "title": "Backstage container additional volumes",
+                    "type": "array",
+                    "items": {
+                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
+                    },
+                    "default": []
+                },
+                "initContainers": {
+                    "title": "Backstage container init containers",
+                    "type": "array",
+                    "items": {
+                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
+                    },
+                    "default": []
+                },
+                "installDir": {
+                    "title": "Directory containing the backstage installation",
+                    "type": "string",
+                    "default": "/app"
+                },
+                "resources": {
+                    "title": "Resource requests/limits",
+                    "description": "Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container",
+                    "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+                    "default": {},
+                    "examples": [
+                        {
+                            "limits": {
+                                "memory": "1Gi",
+                                "cpu": "1000m"
+                            },
+                            "requests": {
+                                "memory": "250Mi",
+                                "cpu": "100m"
+                            }
+                        }
+                    ]
+                },
+                "podSecurityContext": {
+                    "title": "Security settings for a Pod.",
+                    "description": "The security settings that you specify for a Pod apply to all Containers in the Pod. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod",
+                    "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
+                    "default": {}
+                },
+                "containerSecurityContext": {
+                    "title": "Security settings for a Container.",
+                    "description": "Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container",
+                    "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
+                    "default": {}
+                },
+                "appConfig": {
+                    "title": "Generates ConfigMap and configures it in the Backstage pods",
+                    "type": "object",
+                    "default": {},
+                    "examples": [
+                        {
+                            "app": {
+                                "baseUrl": "https://somedomain.tld"
+                            }
+                        }
+                    ]
+                },
+                "nodeSelector": {
+                    "title": "Node labels for pod assignment",
+                    "description": "Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {}
+                },
+                "tolerations": {
+                    "title": "Node tolerations for server scheduling to nodes with taints",
+                    "description": "Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/",
+                    "type": "array",
+                    "items": {
+                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Toleration"
+                    },
+                    "default": []
+                },
+                "podAnnotations": {
+                    "title": "Annotations to add to the backend deployment pods",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {}
+                },
+                "annotations": {
+                    "title": "Additional custom annotations for the `Deployment` resource",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {}
+                }
+            }
+        },
+        "service": {
+            "title": "Service parameters",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "title": "Kubernetes Service type",
+                    "type": "string",
+                    "default": "ClusterIP",
+                    "enum": [
+                        "ClusterIP",
+                        "NodePort",
+                        "LoadBalancer",
+                        "ExternalName"
+                    ]
+                },
+                "ports": {
+                    "title": "Backstage svc port for client connections",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "backend": {
+                            "title": "Backstage svc port number",
+                            "type": "integer",
+                            "default": 7007
+                        },
+                        "name": {
+                            "title": "Backstage svc port name",
+                            "type": "string",
+                            "default": "http-backend"
+                        },
+                        "targetPort": {
+                            "title": "Backstage svc target port referencing receiving pod container port",
+                            "type": "string",
+                            "default": "backend"
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "title": "Node port for the Backstage client connections",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "backend": {
+                            "title": "Node port for backend",
+                            "type": [
+                                "string",
+                                "integer"
+                            ],
+                            "default": "",
+                            "minimum": 30000,
+                            "maximum": 32767
+                        }
+                    }
+                },
+                "sessionAffinity": {
+                    "title": "Control where client requests go, to the same pod or round-robin",
+                    "description": "Ref: https://kubernetes.io/docs/concepts/services-networking/service/#session-stickiness",
+                    "type": "string",
+                    "default": "None",
+                    "enum": [
+                        "None",
+                        "ClientIP"
+                    ]
+                },
+                "clusterIP": {
+                    "title": "Backstage service Cluster IP",
+                    "type": "string",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "title": "Backstage service Load Balancer IP",
+                    "description": "Ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer",
+                    "type": "string",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "title": "Load Balancer sources",
+                    "description": "Ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "examples": [
+                        "10.10.10.0/24"
+                    ]
+                },
+                "externalTrafficPolicy": {
+                    "title": "Backstage service external traffic policy",
+                    "description": "Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip",
+                    "type": "string",
+                    "default": "Cluster",
+                    "enum": [
+                        "Cluster",
+                        "Local"
+                    ]
+                },
+                "annotations": {
+                    "title": "Additional custom annotations for Backstage service",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {}
+                },
+                "extraPorts": {
+                    "title": "Extra ports to expose in the Backstage service",
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    },
+                    "default": []
+                }
+            }
+        },
+        "networkPolicy": {
+            "title": "Network policies",
+            "description": "Not used in any template. Ref. https://kubernetes.io/docs/concepts/services-networking/network-policies/",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "title": "Specifies whether a NetworkPolicy should be created",
+                    "type": "boolean",
+                    "default": false
+                },
+                "externalAccess": {
+                    "title": "Probably custom ingress rules for the network policy",
+                    "type": "object"
+                },
+                "egressRules": {
+                    "title": "Custom egress rules for the network policy",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "customRules": {
+                            "title": "",
+                            "type": "array",
+                            "items": {
+                                "$ref": "https://kubernetesjsonschema.dev/v1.8.7/_definitions.json#/definitions/io.k8s.api.networking.v1.NetworkPolicyEgressRule"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "postgresql": {
+        "title": "PostgreSQL chart configuration",
+        "description": "Ref. https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml",
+        "$ref": "https://raw.githubusercontent.com/bitnami/charts/main/bitnami/postgresql/values.schema.json"
+    },
+    "serviceAccount": {
+        "title": "Service Account Configuration",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "create": {
+                "title": "Enable the creation of a ServiceAccount for Backstage pods",
+                "type": "boolean",
+                "default": false
+            },
+            "name": {
+                "title": "Name of the ServiceAccount to use",
+                "description": "If not set and `serviceAccount.create` is true, a name is generated",
+                "type": "string",
+                "default": ""
+            },
+            "labels": {
+                "title": "Additional custom labels to the service ServiceAccount.",
+                "type": "object",
+                "additionalProperties": {
+                    "type": "string"
+                },
+                "default": {}
+            },
+            "annotations": {
+                "title": "Additional custom annotations for the ServiceAccount.",
+                "type": "object",
+                "additionalProperties": {
+                    "type": "string"
+                },
+                "default": {}
+            },
+            "automountServiceAccountToken": {
+                "title": "Auto-mount the service account token in the pod",
+                "type": "boolean",
+                "default": true
+            }
+        }
+    },
+    "metrics": {
+        "title": "Metrics configuration",
+        "description": "Allows configuring your backstage instance as a scrape target for Prometheus. Ref: https://github.com/prometheus/prometheus",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "serviceMonitor": {
+                "title": "ServiceMonitor configuration",
+                "description": "A custom resource that is consumed by Prometheus Operator. Ref: https://github.com/prometheus-operator/prometheus-operator",
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "enabled": {
+                        "title": "If enabled, a ServiceMonitor resource for Prometheus Operator is created",
+                        "description": "Prometheus Operator must be installed in your cluster prior to enabling.",
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "annotations": {
+                        "title": "ServiceMonitor annotations",
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "default": {}
+                    },
+                    "labels": {
+                        "title": "Additional ServiceMonitor labels",
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "default": {}
+                    },
+                    "interval": {
+                        "title": "ServiceMonitor scrape interval",
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "default": null
+                    },
+                    "path": {
+                        "title": "ServiceMonitor endpoint path",
+                        "description": "ote that the /metrics endpoint is NOT present in a freshly scaffolded Backstage app. To setup, follow the Prometheus metrics tutorial. https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/prometheus-metrics.md",
+                        "type": "string",
+                        "default": "/metrics"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -96,7 +96,7 @@ backstage:
 
     # -- Specify a imagePullPolicy.
     # Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-    # <br /> Ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    # <br /> Ref: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
     pullPolicy: Always
 
     # -- Optionally specify an array of imagePullSecrets.
@@ -143,7 +143,7 @@ backstage:
   installDir: /app
 
   # -- Resource requests/limits
-  # <br /> Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  # <br /> Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
   # <!-- E.g.
   # resources:
   #   limits:
@@ -174,11 +174,11 @@ backstage:
   appConfig: {}
 
   # -- Node labels for pod assignment
-  # <br /> Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # <br /> Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector: {}
 
   # -- Node tolerations for server scheduling to nodes with taints
-  # <br /> Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  # <br /> Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   tolerations: []
   #  - key: "key"
   #    operator: "Equal|Exists"
@@ -219,7 +219,7 @@ service:
 
   # -- Control where client requests go, to the same pod or round-robin
   # (values: `ClientIP` or `None`)
-  # <br /> Ref: https://kubernetes.io/docs/user-guide/services/
+  # <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/service/#session-stickiness
   sessionAffinity: None
 
   # -- Backstage service Cluster IP
@@ -229,12 +229,12 @@ service:
 
   # -- Backstage service Load Balancer IP
   #
-  # <br /> Ref: https://kubernetes.io/docs/user-guide/services/#type-loadbalancer
+  # <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
   loadBalancerIP: ""
 
   # -- Load Balancer sources
   #
-  # <br /> Ref: https://kubernetes.io/docs/tasks/access-application-cluster/cnfigure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  # <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
   # <br /> E.g `loadBalancerSourceRanges: [10.10.10.0/24]`
   loadBalancerSourceRanges: []
 


### PR DESCRIPTION
## Description of the change

Implements JSON schema for the chart and enriches `Chart.yaml` with additional metadata

## Existing or Associated Issue(s)

Resolves #14 

## Additional Information

Schema was written manually since there's no automation available as far as I know.

Schema includes remote references to:
- Bitnami/PostgreSQL's [`values.schema.json`](https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.schema.json)
- https://kubernetesjsonschema.dev (outdated but sufficient)
    - `io.k8s.api.core.v1.Container`
    - `io.k8s.api.core.v1.EnvVar`
    - `io.k8s.api.core.v1.VolumeMount`
    - `io.k8s.api.core.v1.Volume`
    - `io.k8s.api.core.v1.ResourceRequirements`
    - `io.k8s.api.core.v1.SecurityContext`
    - `io.k8s.api.core.v1.Toleration`
    - `io.k8s.api.networking.v1.NetworkPolicyEgressRule`

Additionally, I've fixed:
- a few broken links in `values.yaml` references to kubernetes documentantion
- found out about #91 
- added annotations/keywords and other metadata into `Chart.yaml` that would allow us to publish better to ArtifactHub.


## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
Signed-off-by: Tomas Coufal <tcoufal@redhat.com>