### PR TITLE
chore: set required kubeVersion because of Ingress resource

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -25,6 +25,7 @@ icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/backstage/i
 keywords:
   - backstage
   - idp
+kubeVersion: ">= 1.19.0-0"
 maintainers:
   - name: Backstage
     url: https://backstage.io
@@ -37,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.22.1
+version: 0.22.2

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # Backstage Helm Chart
 
-![Version: 0.22.1](https://img.shields.io/badge/Version-0.22.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.22.2](https://img.shields.io/badge/Version-0.22.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
 
@@ -99,6 +99,8 @@ helm uninstall my-backstage-release
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
 ## Requirements
+
+Kubernetes: `>= 1.19.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|


### PR DESCRIPTION
## Description of the change

The latest kubernetes version restriction I've found is that our chart uses `Ingress` resource which went GA in `1.19.0`.

## Existing or Associated Issue(s)

N/A

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
