### PR TITLE
Change extraEnvVarsSecrets item type to string

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.22.2
+version: 0.22.3

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # Backstage Helm Chart
 
-![Version: 0.22.2](https://img.shields.io/badge/Version-0.22.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.22.3](https://img.shields.io/badge/Version-0.22.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
 

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -306,7 +306,7 @@
                     "type": "array",
                     "description": "Translates into array of `envFrom.[].secretRef.name`",
                     "items": {
-                        "type": "object"
+                        "type": "string"
                     },
                     "default": [],
                     "examples": [


### PR DESCRIPTION
changing the type of extraEnvVarsSecrets to string as providing a valid secret name as an array item is resulting in the error backstage.extraEnvVarsSecrets.0: Invalid type. Expected: object, given: string
```
 extraEnvVarsSecrets:
    - <secret-name>
```