### PR TITLE
chore: fix artifacthub badge

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.22.4
+version: 0.22.5

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,8 +1,8 @@
 
 # Backstage Helm Chart
 
-[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/janus-idp&style=flat-square)](https://artifacthub.io/packages/search?repo=janus-idp)
-![Version: 0.22.4](https://img.shields.io/badge/Version-0.22.4-informational?style=flat-square)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
+![Version: 0.22.5](https://img.shields.io/badge/Version-0.22.5-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -2,7 +2,7 @@
 
 {{ template "chart.deprecationWarning" . }}
 
-[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/janus-idp&style=flat-square)](https://artifacthub.io/packages/search?repo=janus-idp)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
 {{ template "chart.versionBadge" . }}
 {{ template "chart.typeBadge" . }}
 


### PR DESCRIPTION
I was too quick to merge #102 and noticed this typo right after clicking the merge button. I apologize, it's a copy-paste error from when I was enabling the same in our vendor-specific chart in Janus IDP.