### PR TITLE
fix(schema): all properties should be nested under `properties` key

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -608,99 +608,99 @@
                     }
                 }
             }
-        }
-    },
-    "postgresql": {
-        "title": "PostgreSQL chart configuration",
-        "description": "Ref. https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml",
-        "$ref": "https://raw.githubusercontent.com/bitnami/charts/main/bitnami/postgresql/values.schema.json"
-    },
-    "serviceAccount": {
-        "title": "Service Account Configuration",
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-            "create": {
-                "title": "Enable the creation of a ServiceAccount for Backstage pods",
-                "type": "boolean",
-                "default": false
-            },
-            "name": {
-                "title": "Name of the ServiceAccount to use",
-                "description": "If not set and `serviceAccount.create` is true, a name is generated",
-                "type": "string",
-                "default": ""
-            },
-            "labels": {
-                "title": "Additional custom labels to the service ServiceAccount.",
-                "type": "object",
-                "additionalProperties": {
-                    "type": "string"
+        },
+        "postgresql": {
+            "title": "PostgreSQL chart configuration",
+            "description": "Ref. https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml",
+            "$ref": "https://raw.githubusercontent.com/bitnami/charts/main/bitnami/postgresql/values.schema.json"
+        },
+        "serviceAccount": {
+            "title": "Service Account Configuration",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "create": {
+                    "title": "Enable the creation of a ServiceAccount for Backstage pods",
+                    "type": "boolean",
+                    "default": false
                 },
-                "default": {}
-            },
-            "annotations": {
-                "title": "Additional custom annotations for the ServiceAccount.",
-                "type": "object",
-                "additionalProperties": {
-                    "type": "string"
+                "name": {
+                    "title": "Name of the ServiceAccount to use",
+                    "description": "If not set and `serviceAccount.create` is true, a name is generated",
+                    "type": "string",
+                    "default": ""
                 },
-                "default": {}
-            },
-            "automountServiceAccountToken": {
-                "title": "Auto-mount the service account token in the pod",
-                "type": "boolean",
-                "default": true
+                "labels": {
+                    "title": "Additional custom labels to the service ServiceAccount.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {}
+                },
+                "annotations": {
+                    "title": "Additional custom annotations for the ServiceAccount.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "title": "Auto-mount the service account token in the pod",
+                    "type": "boolean",
+                    "default": true
+                }
             }
-        }
-    },
-    "metrics": {
-        "title": "Metrics configuration",
-        "description": "Allows configuring your backstage instance as a scrape target for Prometheus. Ref: https://github.com/prometheus/prometheus",
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-            "serviceMonitor": {
-                "title": "ServiceMonitor configuration",
-                "description": "A custom resource that is consumed by Prometheus Operator. Ref: https://github.com/prometheus-operator/prometheus-operator",
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "enabled": {
-                        "title": "If enabled, a ServiceMonitor resource for Prometheus Operator is created",
-                        "description": "Prometheus Operator must be installed in your cluster prior to enabling.",
-                        "type": "boolean",
-                        "default": false
-                    },
-                    "annotations": {
-                        "title": "ServiceMonitor annotations",
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "string"
+        },
+        "metrics": {
+            "title": "Metrics configuration",
+            "description": "Allows configuring your backstage instance as a scrape target for Prometheus. Ref: https://github.com/prometheus/prometheus",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "serviceMonitor": {
+                    "title": "ServiceMonitor configuration",
+                    "description": "A custom resource that is consumed by Prometheus Operator. Ref: https://github.com/prometheus-operator/prometheus-operator",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "title": "If enabled, a ServiceMonitor resource for Prometheus Operator is created",
+                            "description": "Prometheus Operator must be installed in your cluster prior to enabling.",
+                            "type": "boolean",
+                            "default": false
                         },
-                        "default": {}
-                    },
-                    "labels": {
-                        "title": "Additional ServiceMonitor labels",
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "string"
+                        "annotations": {
+                            "title": "ServiceMonitor annotations",
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "default": {}
                         },
-                        "default": {}
-                    },
-                    "interval": {
-                        "title": "ServiceMonitor scrape interval",
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "default": null
-                    },
-                    "path": {
-                        "title": "ServiceMonitor endpoint path",
-                        "description": "ote that the /metrics endpoint is NOT present in a freshly scaffolded Backstage app. To setup, follow the Prometheus metrics tutorial. https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/prometheus-metrics.md",
-                        "type": "string",
-                        "default": "/metrics"
+                        "labels": {
+                            "title": "Additional ServiceMonitor labels",
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "default": {}
+                        },
+                        "interval": {
+                            "title": "ServiceMonitor scrape interval",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "default": null
+                        },
+                        "path": {
+                            "title": "ServiceMonitor endpoint path",
+                            "description": "ote that the /metrics endpoint is NOT present in a freshly scaffolded Backstage app. To setup, follow the Prometheus metrics tutorial. https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/prometheus-metrics.md",
+                            "type": "string",
+                            "default": "/metrics"
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Description of the change

When using chart values schema I've noticed I made a mistake in https://github.com/backstage/charts/pull/92 and instead of nesting all `properties` under the `properties` key, some were left under the schema root. This doesn't resolve as a valid property and therefore it makes schemas of affected keys unusable.

Affected keys:

- `postgresql`
- `serviceAccount`
- `metrics`

## Existing or Associated Issue(s)

N/A

## Additional Information

Git diff looks a bit weird, however all changeset is just about nesting affected properties one level deeper aka "add 4 spaces and move a coma".

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
