### PR TITLE
Allow appConfig to be provided as a string

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square)
+![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -416,7 +416,10 @@
                 },
                 "appConfig": {
                     "title": "Generates ConfigMap and configures it in the Backstage pods",
-                    "type": "object",
+                    "type": [
+                        "object",
+                        "string"
+                    ],
                     "default": {},
                     "examples": [
                         {


### PR DESCRIPTION
## Description of the Bug

Providing the value for `backstage.appConfig` as a string does technically work, but is not allowed by the schema.

## Description of the change

Allow key `backstage.appConfig` to be of type `object` or `string`.

## Existing or Associated Issue(s)

None

## Additional Information

The template `app-config-configmap.yaml` uses the `common.tplvalues.render` helper function from the bitnami common chart.

https://github.com/backstage/charts/blob/b1d86d306a066282ceba5206ba8267f78fbbb464/charts/backstage/templates/app-config-configmap.yaml#L7-L8

That helper function supports both, `string`-type and `object`-type values.

https://github.com/bitnami/charts/blob/35bc6b1d5d87dfc3875ed09a45bffd2bddc9ee6d/bitnami/common/templates/_tplvalues.tpl#L2-L13

## Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [X] JSON Schema generated.
- [X] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
