### PR TITLE
feat: values.schema.json to support air-gapped environments

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+
+values.schema.tmpl.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,11 @@ repos:
           - --template-files=./_templates.gotmpl
           # A base filename makes it relative to each chart directory found
           - --template-files=README.md.gotmpl
+  - repo: local
+    hooks:
+      - id: jsonschema-dereference
+        name: jsonschema-dereference
+        entry: python .pre-commit/jsonschema-dereference.py
+        additional_dependencies: [jsonref]
+        language: python
+        types_or: [yaml, json]

--- a/.pre-commit/jsonschema-dereference.py
+++ b/.pre-commit/jsonschema-dereference.py
@@ -1,0 +1,34 @@
+import json
+from typing import List, Dict, Any
+from pathlib import Path
+
+import jsonref
+
+JSONSCHEMA_TEMPLATE_NAME = "values.schema.tmpl.json"
+JSONSCHEMA_NAME = "values.schema.json"
+CHART_LOCK = "Chart.lock"
+
+def load_template_schema(chart_dir: Path) -> Dict[str, Any]:
+    """Load values.schema.tmpl.json and template it via Jinja2."""
+    with open(chart_dir / JSONSCHEMA_TEMPLATE_NAME, "r") as f:
+        return json.loads(f.read())
+
+def save(chart_dir: Path, schema: Any):
+    """Take schema containing $refs and dereference them."""
+    with open(chart_dir / JSONSCHEMA_NAME, "w") as f:
+        json.dump(schema, f, indent=4, sort_keys=True)
+
+if __name__ == '__main__':
+    charts = [p.parent for p in Path(".").rglob(CHART_LOCK)]
+
+    errors: List[BaseException] = []
+    for chart in charts:
+        try:
+            schema_template = load_template_schema(chart)
+            schema = jsonref.replace_refs(schema_template)
+            save(chart, schema)
+        except BaseException as e:
+            print(f"Could not process schema for '{chart}': {e}")
+            errors.append(e)
+    if errors:
+        exit(1)

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.1
+version: 1.6.0

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square)
+![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -1,302 +1,1190 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "type": "object",
-    "title": "Backstage chart schema",
     "properties": {
-        "global": {
-            "title": "Global parameters.",
-            "type": "object",
+        "backstage": {
+            "additionalProperties": false,
             "properties": {
-                "imageRegistry": {
-                    "title": "Global Docker image registry",
-                    "type": "string",
-                    "default": ""
+                "annotations": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {},
+                    "title": "Additional custom annotations for the `Deployment` resource",
+                    "type": "object"
                 },
-                "imagePullSecrets": {
-                    "title": "Global Docker registry secret names as an array",
-                    "type": "array",
+                "appConfig": {
+                    "default": {},
+                    "examples": [
+                        {
+                            "app": {
+                                "baseUrl": "https://somedomain.tld"
+                            }
+                        }
+                    ],
+                    "title": "Generates ConfigMap and configures it in the Backstage pods",
+                    "type": [
+                        "object",
+                        "string"
+                    ]
+                },
+                "args": {
                     "default": [],
                     "items": {
                         "type": "string"
                     },
-                    "uniqueItems": true,
-                    "examples": [
-                        [
-                            "myRegistryKeySecretName"
-                        ]
-                    ]
-                }
-            }
-        },
-        "kubeVersion": {
-            "title": "Override Kubernetes version",
-            "type": "string",
-            "default": ""
-        },
-        "nameOverride": {
-            "title": "String to partially override common.names.fullname",
-            "type": "string",
-            "default": ""
-        },
-        "fullnameOverride": {
-            "title": "String to fully override common.names.fullname",
-            "type": "string",
-            "default": ""
-        },
-        "clusterDomain": {
-            "title": "Default Kubernetes cluster domain",
-            "type": "string",
-            "default": "cluster.local"
-        },
-        "commonLabels": {
-            "title": "Labels to add to all deployed objects",
-            "type": "object",
-            "additionalProperties": {
-                "type": "string"
-            },
-            "default": {}
-        },
-        "commonAnnotations": {
-            "title": "Annotations to add to all deployed objects",
-            "type": "object",
-            "additionalProperties": {
-                "type": "string"
-            },
-            "default": {}
-        },
-        "extraDeploy": {
-            "title": "Array of extra objects to deploy with the release",
-            "type": "array",
-            "default": [],
-            "items": {
-                "type": [
-                    "string",
-                    "object"
-                ]
-            },
-            "uniqueItems": true
-        },
-        "diagnosticMode": {
-            "title": "Enable diagnostic mode in the Deployment",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "enabled": {
-                    "title": "Enable diagnostic mode",
-                    "description": "All probes will be disabled and the command will be overridden",
-                    "type": "boolean",
-                    "default": false
+                    "title": "Backstage container command arguments",
+                    "type": "array"
                 },
                 "command": {
-                    "title": "Command to override all containers in the Deployment",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "sleep"
-                    ]
-                },
-                "args": {
-                    "title": "Args to override all containers in the Deployment",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [
-                        "infinity"
-                    ]
-                }
-            }
-        },
-        "ingress": {
-            "title": "Ingress parameters",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "enabled": {
-                    "title": "Enable the creation of the ingress resource",
-                    "type": "boolean",
-                    "default": false
-                },
-                "className": {
-                    "title": "Name of the IngressClass cluster resource which defines which controller will implement the resource.",
-                    "type": "string",
-                    "default": "",
-                    "examples": [
-                        "nginx"
-                    ]
-                },
-                "annotations": {
-                    "title": "Additional annotations for the Ingress resource",
-                    "type": "object",
-                    "default": {},
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "host": {
-                    "title": "Hostname to be used to expose the route to access the backstage application.",
-                    "type": "string",
-                    "default": "",
-                    "examples": [
-                        "backstage.10.0.0.1.nip.io"
-                    ]
-                },
-                "tls": {
-                    "title": "Ingress TLS parameters",
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "enabled": {
-                            "title": "Enable TLS configuration",
-                            "description": "TLS for the host defined at `ingress.host` parameter",
-                            "type": "boolean",
-                            "default": false
-                        },
-                        "secretName": {
-                            "title": "The name to which the TLS Secret will be called",
-                            "type": "string",
-                            "default": ""
-                        }
-                    }
-                }
-            }
-        },
-        "backstage": {
-            "title": "Backstage parameters",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "replicas": {
-                    "title": "Number of deployment replicas",
-                    "type": "integer",
-                    "minimum": 0,
-                    "default": 1
-                },
-                "revisionHistoryLimit": {
-                    "title": "The count of deployment revisions",
-                    "type": "integer",
-                    "minimum": 0,
-                    "default": 10
-                },
-                "image": {
-                    "title": "Image parameters",
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "registry": {
-                            "title": "Backstage image registry",
-                            "type": "string",
-                            "default": "ghcr.io",
-                            "examples": [
-                                "ghcr.io",
-                                "quay.io",
-                                "docker.io"
-                            ]
-                        },
-                        "repository": {
-                            "title": "Backstage image repository",
-                            "type": "string",
-                            "default": "backstage/backstage"
-                        },
-                        "tag": {
-                            "title": "Backstage image tag",
-                            "description": "Immutable tags are recommended.",
-                            "type": "string",
-                            "default": "latest"
-                        },
-                        "pullPolicy": {
-                            "title": "Specify a imagePullPolicy.",
-                            "description": "Ref: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy",
-                            "type": "string",
-                            "default": "Always",
-                            "enum": [
-                                "Always",
-                                "IfNotPresent"
-                            ]
-                        },
-                        "pullSecrets": {
-                            "title": "Optionally specify an array of imagePullSecrets.",
-                            "description": "Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/",
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            },
-                            "default": [],
-                            "examples": [
-                                "myRegistryKeySecretName"
-                            ]
-                        },
-                        "debug": {
-                            "title": "Set to true if you would like to see extra information on logs",
-                            "type": "boolean",
-                            "default": false
-                        }
-                    }
-                },
-                "containerPorts": {
-                    "title": "Container ports on the Deployment",
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "backend": {
-                            "title": "Backstage backend port.",
-                            "type": "integer",
-                            "default": 7007
-                        }
-                    }
-                },
-                "command": {
-                    "title": "Backstage container command",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
                     "default": [
                         "node",
                         "packages/backend"
-                    ]
-                },
-                "args": {
-                    "title": "Backstage container command arguments",
-                    "type": "array",
+                    ],
                     "items": {
                         "type": "string"
                     },
-                    "default": []
+                    "title": "Backstage container command",
+                    "type": "array"
                 },
-                "extraAppConfig": {
-                    "title": "Extra app configuration files to inline into command arguments",
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "additionalProperties": false,
-                        "properties": {
-                            "filename": {
-                                "type": "string"
-                            },
-                            "configMapRef": {
-                                "type": "string"
-                            }
+                "containerPorts": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "backend": {
+                            "default": 7007,
+                            "title": "Backstage backend port.",
+                            "type": "integer"
                         }
                     },
-                    "default": []
+                    "title": "Container ports on the Deployment",
+                    "type": "object"
+                },
+                "containerSecurityContext": {
+                    "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+                    "properties": {
+                        "allowPrivilegeEscalation": {
+                            "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+                            "type": "boolean"
+                        },
+                        "capabilities": {
+                            "description": "Adds and removes POSIX capabilities from running containers.",
+                            "properties": {
+                                "add": {
+                                    "description": "Added capabilities",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                "drop": {
+                                    "description": "Removed capabilities",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "privileged": {
+                            "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+                            "type": "boolean"
+                        },
+                        "procMount": {
+                            "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+                            "type": "string"
+                        },
+                        "readOnlyRootFilesystem": {
+                            "description": "Whether this container has a read-only root filesystem. Default is false.",
+                            "type": "boolean"
+                        },
+                        "runAsGroup": {
+                            "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "format": "int64",
+                            "type": "integer"
+                        },
+                        "runAsNonRoot": {
+                            "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": "boolean"
+                        },
+                        "runAsUser": {
+                            "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "format": "int64",
+                            "type": "integer"
+                        },
+                        "seLinuxOptions": {
+                            "description": "SELinuxOptions are the labels to be applied to the container",
+                            "properties": {
+                                "level": {
+                                    "description": "Level is SELinux level label that applies to the container.",
+                                    "type": "string"
+                                },
+                                "role": {
+                                    "description": "Role is a SELinux role label that applies to the container.",
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "description": "Type is a SELinux type label that applies to the container.",
+                                    "type": "string"
+                                },
+                                "user": {
+                                    "description": "User is a SELinux user label that applies to the container.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "windowsOptions": {
+                            "description": "WindowsSecurityContextOptions contain Windows-specific options and credentials.",
+                            "properties": {
+                                "gmsaCredentialSpec": {
+                                    "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                    "type": "string"
+                                },
+                                "gmsaCredentialSpecName": {
+                                    "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                    "type": "string"
+                                },
+                                "runAsUserName": {
+                                    "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "extraAppConfig": {
+                    "default": [],
+                    "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "configMapRef": {
+                                "type": "string"
+                            },
+                            "filename": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "title": "Extra app configuration files to inline into command arguments",
+                    "type": "array"
                 },
                 "extraContainers": {
-                    "title": "Deployment sidecars.",
-                    "type": "array",
+                    "default": [],
                     "items": {
-                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
+                        "description": "A single application container that you want to run within a pod.",
+                        "properties": {
+                            "args": {
+                                "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "command": {
+                                "description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "env": {
+                                "description": "List of environment variables to set in the container. Cannot be updated.",
+                                "items": {
+                                    "description": "EnvVar represents an environment variable present in a Container.",
+                                    "properties": {
+                                        "name": {
+                                            "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                            "type": "string"
+                                        },
+                                        "value": {
+                                            "description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                            "type": "string"
+                                        },
+                                        "valueFrom": {
+                                            "description": "EnvVarSource represents a source for the value of an EnvVar.",
+                                            "properties": {
+                                                "configMapKeyRef": {
+                                                    "description": "Selects a key from a ConfigMap.",
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "The key to select.",
+                                                            "type": "string"
+                                                        },
+                                                        "name": {
+                                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                            "type": "string"
+                                                        },
+                                                        "optional": {
+                                                            "description": "Specify whether the ConfigMap or its key must be defined",
+                                                            "type": "boolean"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "key"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                "fieldRef": {
+                                                    "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+                                                    "properties": {
+                                                        "apiVersion": {
+                                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                            "type": "string"
+                                                        },
+                                                        "fieldPath": {
+                                                            "description": "Path of the field to select in the specified API version.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "fieldPath"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                "resourceFieldRef": {
+                                                    "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+                                                    "properties": {
+                                                        "containerName": {
+                                                            "description": "Container name: required for volumes, optional for env vars",
+                                                            "type": "string"
+                                                        },
+                                                        "divisor": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "resource": {
+                                                            "description": "Required: resource to select",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "resource"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                "secretKeyRef": {
+                                                    "description": "SecretKeySelector selects a key of a Secret.",
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                            "type": "string"
+                                                        },
+                                                        "name": {
+                                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                            "type": "string"
+                                                        },
+                                                        "optional": {
+                                                            "description": "Specify whether the Secret or its key must be defined",
+                                                            "type": "boolean"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "key"
+                                                    ],
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "required": [
+                                        "name"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-patch-merge-key": "name",
+                                "x-kubernetes-patch-strategy": "merge"
+                            },
+                            "envFrom": {
+                                "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                                "items": {
+                                    "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                                    "properties": {
+                                        "configMapRef": {
+                                            "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+                                            "properties": {
+                                                "name": {
+                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                    "type": "string"
+                                                },
+                                                "optional": {
+                                                    "description": "Specify whether the ConfigMap must be defined",
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "prefix": {
+                                            "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                            "type": "string"
+                                        },
+                                        "secretRef": {
+                                            "description": "SecretEnvSource selects a Secret to populate the environment variables with.\n\nThe contents of the target Secret's Data field will represent the key-value pairs as environment variables.",
+                                            "properties": {
+                                                "name": {
+                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                    "type": "string"
+                                                },
+                                                "optional": {
+                                                    "description": "Specify whether the Secret must be defined",
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
+                            "image": {
+                                "description": "Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                                "type": "string"
+                            },
+                            "imagePullPolicy": {
+                                "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                                "type": "string"
+                            },
+                            "lifecycle": {
+                                "description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
+                                "properties": {
+                                    "postStart": {
+                                        "description": "Handler defines a specific action that should be taken",
+                                        "properties": {
+                                            "exec": {
+                                                "description": "ExecAction describes a \"run in container\" action.",
+                                                "properties": {
+                                                    "command": {
+                                                        "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            "httpGet": {
+                                                "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                                "properties": {
+                                                    "host": {
+                                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                        "type": "string"
+                                                    },
+                                                    "httpHeaders": {
+                                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                        "items": {
+                                                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "description": "The header field name",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "description": "The header field value",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name",
+                                                                "value"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "path": {
+                                                        "description": "Path to access on the HTTP server.",
+                                                        "type": "string"
+                                                    },
+                                                    "port": {
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "integer"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "scheme": {
+                                                        "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "port"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "tcpSocket": {
+                                                "description": "TCPSocketAction describes an action based on opening a socket",
+                                                "properties": {
+                                                    "host": {
+                                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                        "type": "string"
+                                                    },
+                                                    "port": {
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "integer"
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "port"
+                                                ],
+                                                "type": "object"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "preStop": {
+                                        "description": "Handler defines a specific action that should be taken",
+                                        "properties": {
+                                            "exec": {
+                                                "description": "ExecAction describes a \"run in container\" action.",
+                                                "properties": {
+                                                    "command": {
+                                                        "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            "httpGet": {
+                                                "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                                "properties": {
+                                                    "host": {
+                                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                        "type": "string"
+                                                    },
+                                                    "httpHeaders": {
+                                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                        "items": {
+                                                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "description": "The header field name",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "description": "The header field value",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name",
+                                                                "value"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "path": {
+                                                        "description": "Path to access on the HTTP server.",
+                                                        "type": "string"
+                                                    },
+                                                    "port": {
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "integer"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "scheme": {
+                                                        "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "port"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "tcpSocket": {
+                                                "description": "TCPSocketAction describes an action based on opening a socket",
+                                                "properties": {
+                                                    "host": {
+                                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                        "type": "string"
+                                                    },
+                                                    "port": {
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "integer"
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "port"
+                                                ],
+                                                "type": "object"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "livenessProbe": {
+                                "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                                "properties": {
+                                    "exec": {
+                                        "description": "ExecAction describes a \"run in container\" action.",
+                                        "properties": {
+                                            "command": {
+                                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "failureThreshold": {
+                                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "httpGet": {
+                                        "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                        "properties": {
+                                            "host": {
+                                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                "type": "string"
+                                            },
+                                            "httpHeaders": {
+                                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                "items": {
+                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                    "properties": {
+                                                        "name": {
+                                                            "description": "The header field name",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "The header field value",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "name",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "path": {
+                                                "description": "Path to access on the HTTP server.",
+                                                "type": "string"
+                                            },
+                                            "port": {
+                                                "oneOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "integer"
+                                                    }
+                                                ]
+                                            },
+                                            "scheme": {
+                                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "port"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "initialDelaySeconds": {
+                                        "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "periodSeconds": {
+                                        "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "successThreshold": {
+                                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "tcpSocket": {
+                                        "description": "TCPSocketAction describes an action based on opening a socket",
+                                        "properties": {
+                                            "host": {
+                                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                "type": "string"
+                                            },
+                                            "port": {
+                                                "oneOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "integer"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "port"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "timeoutSeconds": {
+                                        "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "name": {
+                                "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+                                "type": "string"
+                            },
+                            "ports": {
+                                "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+                                "items": {
+                                    "description": "ContainerPort represents a network port in a single container.",
+                                    "properties": {
+                                        "containerPort": {
+                                            "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                        },
+                                        "hostIP": {
+                                            "description": "What host IP to bind the external port to.",
+                                            "type": "string"
+                                        },
+                                        "hostPort": {
+                                            "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                        },
+                                        "name": {
+                                            "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                                            "type": "string"
+                                        },
+                                        "protocol": {
+                                            "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "containerPort"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                    "containerPort",
+                                    "protocol"
+                                ],
+                                "x-kubernetes-list-type": "map",
+                                "x-kubernetes-patch-merge-key": "containerPort",
+                                "x-kubernetes-patch-strategy": "merge"
+                            },
+                            "readinessProbe": {
+                                "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                                "properties": {
+                                    "exec": {
+                                        "description": "ExecAction describes a \"run in container\" action.",
+                                        "properties": {
+                                            "command": {
+                                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "failureThreshold": {
+                                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "httpGet": {
+                                        "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                        "properties": {
+                                            "host": {
+                                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                "type": "string"
+                                            },
+                                            "httpHeaders": {
+                                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                "items": {
+                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                    "properties": {
+                                                        "name": {
+                                                            "description": "The header field name",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "The header field value",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "name",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "path": {
+                                                "description": "Path to access on the HTTP server.",
+                                                "type": "string"
+                                            },
+                                            "port": {
+                                                "oneOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "integer"
+                                                    }
+                                                ]
+                                            },
+                                            "scheme": {
+                                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "port"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "initialDelaySeconds": {
+                                        "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "periodSeconds": {
+                                        "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "successThreshold": {
+                                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "tcpSocket": {
+                                        "description": "TCPSocketAction describes an action based on opening a socket",
+                                        "properties": {
+                                            "host": {
+                                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                "type": "string"
+                                            },
+                                            "port": {
+                                                "oneOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "integer"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "port"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "timeoutSeconds": {
+                                        "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "resources": {
+                                "description": "ResourceRequirements describes the compute resource requirements.",
+                                "properties": {
+                                    "limits": {
+                                        "additionalProperties": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ]
+                                        },
+                                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                        "type": "object"
+                                    },
+                                    "requests": {
+                                        "additionalProperties": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ]
+                                        },
+                                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "securityContext": {
+                                "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+                                "properties": {
+                                    "allowPrivilegeEscalation": {
+                                        "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+                                        "type": "boolean"
+                                    },
+                                    "capabilities": {
+                                        "description": "Adds and removes POSIX capabilities from running containers.",
+                                        "properties": {
+                                            "add": {
+                                                "description": "Added capabilities",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "drop": {
+                                                "description": "Removed capabilities",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "privileged": {
+                                        "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+                                        "type": "boolean"
+                                    },
+                                    "procMount": {
+                                        "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+                                        "type": "string"
+                                    },
+                                    "readOnlyRootFilesystem": {
+                                        "description": "Whether this container has a read-only root filesystem. Default is false.",
+                                        "type": "boolean"
+                                    },
+                                    "runAsGroup": {
+                                        "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                        "format": "int64",
+                                        "type": "integer"
+                                    },
+                                    "runAsNonRoot": {
+                                        "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                        "type": "boolean"
+                                    },
+                                    "runAsUser": {
+                                        "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                        "format": "int64",
+                                        "type": "integer"
+                                    },
+                                    "seLinuxOptions": {
+                                        "description": "SELinuxOptions are the labels to be applied to the container",
+                                        "properties": {
+                                            "level": {
+                                                "description": "Level is SELinux level label that applies to the container.",
+                                                "type": "string"
+                                            },
+                                            "role": {
+                                                "description": "Role is a SELinux role label that applies to the container.",
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "description": "Type is a SELinux type label that applies to the container.",
+                                                "type": "string"
+                                            },
+                                            "user": {
+                                                "description": "User is a SELinux user label that applies to the container.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "windowsOptions": {
+                                        "description": "WindowsSecurityContextOptions contain Windows-specific options and credentials.",
+                                        "properties": {
+                                            "gmsaCredentialSpec": {
+                                                "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                                "type": "string"
+                                            },
+                                            "gmsaCredentialSpecName": {
+                                                "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                                "type": "string"
+                                            },
+                                            "runAsUserName": {
+                                                "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "startupProbe": {
+                                "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                                "properties": {
+                                    "exec": {
+                                        "description": "ExecAction describes a \"run in container\" action.",
+                                        "properties": {
+                                            "command": {
+                                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "failureThreshold": {
+                                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "httpGet": {
+                                        "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                        "properties": {
+                                            "host": {
+                                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                "type": "string"
+                                            },
+                                            "httpHeaders": {
+                                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                "items": {
+                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                    "properties": {
+                                                        "name": {
+                                                            "description": "The header field name",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "The header field value",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "name",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "path": {
+                                                "description": "Path to access on the HTTP server.",
+                                                "type": "string"
+                                            },
+                                            "port": {
+                                                "oneOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "integer"
+                                                    }
+                                                ]
+                                            },
+                                            "scheme": {
+                                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "port"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "initialDelaySeconds": {
+                                        "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "periodSeconds": {
+                                        "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "successThreshold": {
+                                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "tcpSocket": {
+                                        "description": "TCPSocketAction describes an action based on opening a socket",
+                                        "properties": {
+                                            "host": {
+                                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                "type": "string"
+                                            },
+                                            "port": {
+                                                "oneOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "integer"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "port"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "timeoutSeconds": {
+                                        "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "stdin": {
+                                "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                                "type": "boolean"
+                            },
+                            "stdinOnce": {
+                                "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                                "type": "boolean"
+                            },
+                            "terminationMessagePath": {
+                                "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                                "type": "string"
+                            },
+                            "terminationMessagePolicy": {
+                                "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+                                "type": "string"
+                            },
+                            "tty": {
+                                "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                                "type": "boolean"
+                            },
+                            "volumeDevices": {
+                                "description": "volumeDevices is the list of block devices to be used by the container.",
+                                "items": {
+                                    "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                                    "properties": {
+                                        "devicePath": {
+                                            "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "description": "name must match the name of a persistentVolumeClaim in the pod",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "name",
+                                        "devicePath"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-patch-merge-key": "devicePath",
+                                "x-kubernetes-patch-strategy": "merge"
+                            },
+                            "volumeMounts": {
+                                "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+                                "items": {
+                                    "description": "VolumeMount describes a mounting of a Volume within a container.",
+                                    "properties": {
+                                        "mountPath": {
+                                            "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                                            "type": "string"
+                                        },
+                                        "mountPropagation": {
+                                            "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "description": "This must match the Name of a Volume.",
+                                            "type": "string"
+                                        },
+                                        "readOnly": {
+                                            "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                                            "type": "boolean"
+                                        },
+                                        "subPath": {
+                                            "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                                            "type": "string"
+                                        },
+                                        "subPathExpr": {
+                                            "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "name",
+                                        "mountPath"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-patch-merge-key": "mountPath",
+                                "x-kubernetes-patch-strategy": "merge"
+                            },
+                            "workingDir": {
+                                "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name"
+                        ],
+                        "type": "object"
                     },
-                    "default": []
+                    "title": "Deployment sidecars.",
+                    "type": "array"
                 },
                 "extraEnvVars": {
-                    "title": "Backstage container environment variables",
-                    "type": "array",
-                    "items": {
-                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar"
-                    },
                     "default": [],
                     "examples": [
                         [
@@ -305,468 +1193,3852 @@
                                 "value": "memory"
                             }
                         ]
-                    ]
+                    ],
+                    "items": {
+                        "description": "EnvVar represents an environment variable present in a Container.",
+                        "properties": {
+                            "name": {
+                                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                "type": "string"
+                            },
+                            "valueFrom": {
+                                "description": "EnvVarSource represents a source for the value of an EnvVar.",
+                                "properties": {
+                                    "configMapKeyRef": {
+                                        "description": "Selects a key from a ConfigMap.",
+                                        "properties": {
+                                            "key": {
+                                                "description": "The key to select.",
+                                                "type": "string"
+                                            },
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            },
+                                            "optional": {
+                                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "key"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "fieldRef": {
+                                        "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+                                        "properties": {
+                                            "apiVersion": {
+                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                "type": "string"
+                                            },
+                                            "fieldPath": {
+                                                "description": "Path of the field to select in the specified API version.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "fieldPath"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "resourceFieldRef": {
+                                        "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+                                        "properties": {
+                                            "containerName": {
+                                                "description": "Container name: required for volumes, optional for env vars",
+                                                "type": "string"
+                                            },
+                                            "divisor": {
+                                                "oneOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    }
+                                                ]
+                                            },
+                                            "resource": {
+                                                "description": "Required: resource to select",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "resource"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "secretKeyRef": {
+                                        "description": "SecretKeySelector selects a key of a Secret.",
+                                        "properties": {
+                                            "key": {
+                                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                "type": "string"
+                                            },
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            },
+                                            "optional": {
+                                                "description": "Specify whether the Secret or its key must be defined",
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "key"
+                                        ],
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        },
+                        "required": [
+                            "name"
+                        ],
+                        "type": "object"
+                    },
+                    "title": "Backstage container environment variables",
+                    "type": "array"
                 },
                 "extraEnvVarsSecrets": {
-                    "title": "Backstage container environment variables from Secrets",
-                    "type": "array",
-                    "description": "Translates into array of `envFrom.[].secretRef.name`",
-                    "items": {
-                        "type": "string"
-                    },
                     "default": [],
+                    "description": "Translates into array of `envFrom.[].secretRef.name`",
                     "examples": [
                         [
                             "my-backstage-secrets"
                         ]
-                    ]
+                    ],
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "Backstage container environment variables from Secrets",
+                    "type": "array"
                 },
                 "extraVolumeMounts": {
-                    "title": "Backstage container additional volume mounts",
-                    "type": "array",
+                    "default": [],
                     "items": {
-                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount"
+                        "description": "VolumeMount describes a mounting of a Volume within a container.",
+                        "properties": {
+                            "mountPath": {
+                                "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                                "type": "string"
+                            },
+                            "mountPropagation": {
+                                "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "This must match the Name of a Volume.",
+                                "type": "string"
+                            },
+                            "readOnly": {
+                                "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                                "type": "boolean"
+                            },
+                            "subPath": {
+                                "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                                "type": "string"
+                            },
+                            "subPathExpr": {
+                                "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "mountPath"
+                        ],
+                        "type": "object"
                     },
-                    "default": []
+                    "title": "Backstage container additional volume mounts",
+                    "type": "array"
                 },
                 "extraVolumes": {
-                    "title": "Backstage container additional volumes",
-                    "type": "array",
+                    "default": [],
                     "items": {
-                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
+                        "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                        "properties": {
+                            "awsElasticBlockStore": {
+                                "description": "Represents a Persistent Disk resource in AWS.\n\nAn AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.",
+                                "properties": {
+                                    "fsType": {
+                                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                        "type": "string"
+                                    },
+                                    "partition": {
+                                        "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "readOnly": {
+                                        "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                        "type": "boolean"
+                                    },
+                                    "volumeID": {
+                                        "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "volumeID"
+                                ],
+                                "type": "object"
+                            },
+                            "azureDisk": {
+                                "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+                                "properties": {
+                                    "cachingMode": {
+                                        "description": "Host Caching mode: None, Read Only, Read Write.",
+                                        "type": "string"
+                                    },
+                                    "diskName": {
+                                        "description": "The Name of the data disk in the blob storage",
+                                        "type": "string"
+                                    },
+                                    "diskURI": {
+                                        "description": "The URI the data disk in the blob storage",
+                                        "type": "string"
+                                    },
+                                    "fsType": {
+                                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                        "type": "string"
+                                    },
+                                    "kind": {
+                                        "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "required": [
+                                    "diskName",
+                                    "diskURI"
+                                ],
+                                "type": "object"
+                            },
+                            "azureFile": {
+                                "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+                                "properties": {
+                                    "readOnly": {
+                                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                        "type": "boolean"
+                                    },
+                                    "secretName": {
+                                        "description": "the name of secret that contains Azure Storage Account Name and Key",
+                                        "type": "string"
+                                    },
+                                    "shareName": {
+                                        "description": "Share Name",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "secretName",
+                                    "shareName"
+                                ],
+                                "type": "object"
+                            },
+                            "cephfs": {
+                                "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
+                                "properties": {
+                                    "monitors": {
+                                        "description": "Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "path": {
+                                        "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                        "type": "boolean"
+                                    },
+                                    "secretFile": {
+                                        "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                        "type": "string"
+                                    },
+                                    "secretRef": {
+                                        "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "user": {
+                                        "description": "Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "monitors"
+                                ],
+                                "type": "object"
+                            },
+                            "cinder": {
+                                "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
+                                "properties": {
+                                    "fsType": {
+                                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                        "type": "boolean"
+                                    },
+                                    "secretRef": {
+                                        "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "volumeID": {
+                                        "description": "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "volumeID"
+                                ],
+                                "type": "object"
+                            },
+                            "configMap": {
+                                "description": "Adapts a ConfigMap into a volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.",
+                                "properties": {
+                                    "defaultMode": {
+                                        "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "items": {
+                                        "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                        "items": {
+                                            "description": "Maps a string key to a path within a volume.",
+                                            "properties": {
+                                                "key": {
+                                                    "description": "The key to project.",
+                                                    "type": "string"
+                                                },
+                                                "mode": {
+                                                    "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                    "format": "int32",
+                                                    "type": "integer"
+                                                },
+                                                "path": {
+                                                    "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "key",
+                                                "path"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "name": {
+                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                    },
+                                    "optional": {
+                                        "description": "Specify whether the ConfigMap or its keys must be defined",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "csi": {
+                                "description": "Represents a source location of a volume to mount, managed by an external CSI driver",
+                                "properties": {
+                                    "driver": {
+                                        "description": "Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                                        "type": "string"
+                                    },
+                                    "fsType": {
+                                        "description": "Filesystem type to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                                        "type": "string"
+                                    },
+                                    "nodePublishSecretRef": {
+                                        "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "readOnly": {
+                                        "description": "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                                        "type": "boolean"
+                                    },
+                                    "volumeAttributes": {
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        },
+                                        "description": "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                                        "type": "object"
+                                    }
+                                },
+                                "required": [
+                                    "driver"
+                                ],
+                                "type": "object"
+                            },
+                            "downwardAPI": {
+                                "description": "DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.",
+                                "properties": {
+                                    "defaultMode": {
+                                        "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "items": {
+                                        "description": "Items is a list of downward API volume file",
+                                        "items": {
+                                            "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                            "properties": {
+                                                "fieldRef": {
+                                                    "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+                                                    "properties": {
+                                                        "apiVersion": {
+                                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                            "type": "string"
+                                                        },
+                                                        "fieldPath": {
+                                                            "description": "Path of the field to select in the specified API version.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "fieldPath"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                "mode": {
+                                                    "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                    "format": "int32",
+                                                    "type": "integer"
+                                                },
+                                                "path": {
+                                                    "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                                    "type": "string"
+                                                },
+                                                "resourceFieldRef": {
+                                                    "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+                                                    "properties": {
+                                                        "containerName": {
+                                                            "description": "Container name: required for volumes, optional for env vars",
+                                                            "type": "string"
+                                                        },
+                                                        "divisor": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "resource": {
+                                                            "description": "Required: resource to select",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "resource"
+                                                    ],
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "required": [
+                                                "path"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "emptyDir": {
+                                "description": "Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.",
+                                "properties": {
+                                    "medium": {
+                                        "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                                        "type": "string"
+                                    },
+                                    "sizeLimit": {
+                                        "oneOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "fc": {
+                                "description": "Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.",
+                                "properties": {
+                                    "fsType": {
+                                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                        "type": "string"
+                                    },
+                                    "lun": {
+                                        "description": "Optional: FC target lun number",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "readOnly": {
+                                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                        "type": "boolean"
+                                    },
+                                    "targetWWNs": {
+                                        "description": "Optional: FC target worldwide names (WWNs)",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "wwids": {
+                                        "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "flexVolume": {
+                                "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+                                "properties": {
+                                    "driver": {
+                                        "description": "Driver is the name of the driver to use for this volume.",
+                                        "type": "string"
+                                    },
+                                    "fsType": {
+                                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                                        "type": "string"
+                                    },
+                                    "options": {
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        },
+                                        "description": "Optional: Extra command options if any.",
+                                        "type": "object"
+                                    },
+                                    "readOnly": {
+                                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                        "type": "boolean"
+                                    },
+                                    "secretRef": {
+                                        "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                },
+                                "required": [
+                                    "driver"
+                                ],
+                                "type": "object"
+                            },
+                            "flocker": {
+                                "description": "Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.",
+                                "properties": {
+                                    "datasetName": {
+                                        "description": "Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+                                        "type": "string"
+                                    },
+                                    "datasetUUID": {
+                                        "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "gcePersistentDisk": {
+                                "description": "Represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.",
+                                "properties": {
+                                    "fsType": {
+                                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                        "type": "string"
+                                    },
+                                    "partition": {
+                                        "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "pdName": {
+                                        "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "required": [
+                                    "pdName"
+                                ],
+                                "type": "object"
+                            },
+                            "gitRepo": {
+                                "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+                                "properties": {
+                                    "directory": {
+                                        "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+                                        "type": "string"
+                                    },
+                                    "repository": {
+                                        "description": "Repository URL",
+                                        "type": "string"
+                                    },
+                                    "revision": {
+                                        "description": "Commit hash for the specified revision.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "repository"
+                                ],
+                                "type": "object"
+                            },
+                            "glusterfs": {
+                                "description": "Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.",
+                                "properties": {
+                                    "endpoints": {
+                                        "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                        "type": "string"
+                                    },
+                                    "path": {
+                                        "description": "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "required": [
+                                    "endpoints",
+                                    "path"
+                                ],
+                                "type": "object"
+                            },
+                            "hostPath": {
+                                "description": "Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.",
+                                "properties": {
+                                    "path": {
+                                        "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "path"
+                                ],
+                                "type": "object"
+                            },
+                            "iscsi": {
+                                "description": "Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
+                                "properties": {
+                                    "chapAuthDiscovery": {
+                                        "description": "whether support iSCSI Discovery CHAP authentication",
+                                        "type": "boolean"
+                                    },
+                                    "chapAuthSession": {
+                                        "description": "whether support iSCSI Session CHAP authentication",
+                                        "type": "boolean"
+                                    },
+                                    "fsType": {
+                                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+                                        "type": "string"
+                                    },
+                                    "initiatorName": {
+                                        "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+                                        "type": "string"
+                                    },
+                                    "iqn": {
+                                        "description": "Target iSCSI Qualified Name.",
+                                        "type": "string"
+                                    },
+                                    "iscsiInterface": {
+                                        "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+                                        "type": "string"
+                                    },
+                                    "lun": {
+                                        "description": "iSCSI Target Lun number.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "portals": {
+                                        "description": "iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "readOnly": {
+                                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+                                        "type": "boolean"
+                                    },
+                                    "secretRef": {
+                                        "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "targetPortal": {
+                                        "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "targetPortal",
+                                    "iqn",
+                                    "lun"
+                                ],
+                                "type": "object"
+                            },
+                            "name": {
+                                "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                            },
+                            "nfs": {
+                                "description": "Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.",
+                                "properties": {
+                                    "path": {
+                                        "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                        "type": "boolean"
+                                    },
+                                    "server": {
+                                        "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "server",
+                                    "path"
+                                ],
+                                "type": "object"
+                            },
+                            "persistentVolumeClaim": {
+                                "description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).",
+                                "properties": {
+                                    "claimName": {
+                                        "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "required": [
+                                    "claimName"
+                                ],
+                                "type": "object"
+                            },
+                            "photonPersistentDisk": {
+                                "description": "Represents a Photon Controller persistent disk resource.",
+                                "properties": {
+                                    "fsType": {
+                                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                        "type": "string"
+                                    },
+                                    "pdID": {
+                                        "description": "ID that identifies Photon Controller persistent disk",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "pdID"
+                                ],
+                                "type": "object"
+                            },
+                            "portworxVolume": {
+                                "description": "PortworxVolumeSource represents a Portworx volume resource.",
+                                "properties": {
+                                    "fsType": {
+                                        "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                        "type": "boolean"
+                                    },
+                                    "volumeID": {
+                                        "description": "VolumeID uniquely identifies a Portworx volume",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "volumeID"
+                                ],
+                                "type": "object"
+                            },
+                            "projected": {
+                                "description": "Represents a projected volume source",
+                                "properties": {
+                                    "defaultMode": {
+                                        "description": "Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "sources": {
+                                        "description": "list of volume projections",
+                                        "items": {
+                                            "description": "Projection that may be projected along with other supported volume types",
+                                            "properties": {
+                                                "configMap": {
+                                                    "description": "Adapts a ConfigMap into a projected volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.",
+                                                    "properties": {
+                                                        "items": {
+                                                            "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                                            "items": {
+                                                                "description": "Maps a string key to a path within a volume.",
+                                                                "properties": {
+                                                                    "key": {
+                                                                        "description": "The key to project.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "mode": {
+                                                                        "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                        "format": "int32",
+                                                                        "type": "integer"
+                                                                    },
+                                                                    "path": {
+                                                                        "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "key",
+                                                                    "path"
+                                                                ],
+                                                                "type": "object"
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        "name": {
+                                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                            "type": "string"
+                                                        },
+                                                        "optional": {
+                                                            "description": "Specify whether the ConfigMap or its keys must be defined",
+                                                            "type": "boolean"
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "downwardAPI": {
+                                                    "description": "Represents downward API info for projecting into a projected volume. Note that this is identical to a downwardAPI volume source without the default mode.",
+                                                    "properties": {
+                                                        "items": {
+                                                            "description": "Items is a list of DownwardAPIVolume file",
+                                                            "items": {
+                                                                "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                                                "properties": {
+                                                                    "fieldRef": {
+                                                                        "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+                                                                        "properties": {
+                                                                            "apiVersion": {
+                                                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "fieldPath": {
+                                                                                "description": "Path of the field to select in the specified API version.",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "fieldPath"
+                                                                        ],
+                                                                        "type": "object"
+                                                                    },
+                                                                    "mode": {
+                                                                        "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                        "format": "int32",
+                                                                        "type": "integer"
+                                                                    },
+                                                                    "path": {
+                                                                        "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "resourceFieldRef": {
+                                                                        "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+                                                                        "properties": {
+                                                                            "containerName": {
+                                                                                "description": "Container name: required for volumes, optional for env vars",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "divisor": {
+                                                                                "oneOf": [
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "number"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "resource": {
+                                                                                "description": "Required: resource to select",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "resource"
+                                                                        ],
+                                                                        "type": "object"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "path"
+                                                                ],
+                                                                "type": "object"
+                                                            },
+                                                            "type": "array"
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "secret": {
+                                                    "description": "Adapts a secret into a projected volume.\n\nThe contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.",
+                                                    "properties": {
+                                                        "items": {
+                                                            "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                                            "items": {
+                                                                "description": "Maps a string key to a path within a volume.",
+                                                                "properties": {
+                                                                    "key": {
+                                                                        "description": "The key to project.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "mode": {
+                                                                        "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                        "format": "int32",
+                                                                        "type": "integer"
+                                                                    },
+                                                                    "path": {
+                                                                        "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "key",
+                                                                    "path"
+                                                                ],
+                                                                "type": "object"
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        "name": {
+                                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                            "type": "string"
+                                                        },
+                                                        "optional": {
+                                                            "description": "Specify whether the Secret or its key must be defined",
+                                                            "type": "boolean"
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "serviceAccountToken": {
+                                                    "description": "ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).",
+                                                    "properties": {
+                                                        "audience": {
+                                                            "description": "Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+                                                            "type": "string"
+                                                        },
+                                                        "expirationSeconds": {
+                                                            "description": "ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+                                                            "format": "int64",
+                                                            "type": "integer"
+                                                        },
+                                                        "path": {
+                                                            "description": "Path is the path relative to the mount point of the file to project the token into.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "path"
+                                                    ],
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "required": [
+                                    "sources"
+                                ],
+                                "type": "object"
+                            },
+                            "quobyte": {
+                                "description": "Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.",
+                                "properties": {
+                                    "group": {
+                                        "description": "Group to map volume access to Default is no group",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+                                        "type": "boolean"
+                                    },
+                                    "registry": {
+                                        "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+                                        "type": "string"
+                                    },
+                                    "tenant": {
+                                        "description": "Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                                        "type": "string"
+                                    },
+                                    "user": {
+                                        "description": "User to map volume access to Defaults to serivceaccount user",
+                                        "type": "string"
+                                    },
+                                    "volume": {
+                                        "description": "Volume is a string that references an already created Quobyte volume by name.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "registry",
+                                    "volume"
+                                ],
+                                "type": "object"
+                            },
+                            "rbd": {
+                                "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
+                                "properties": {
+                                    "fsType": {
+                                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+                                        "type": "string"
+                                    },
+                                    "image": {
+                                        "description": "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                        "type": "string"
+                                    },
+                                    "keyring": {
+                                        "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                        "type": "string"
+                                    },
+                                    "monitors": {
+                                        "description": "A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "pool": {
+                                        "description": "The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                        "type": "boolean"
+                                    },
+                                    "secretRef": {
+                                        "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "user": {
+                                        "description": "The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "monitors",
+                                    "image"
+                                ],
+                                "type": "object"
+                            },
+                            "scaleIO": {
+                                "description": "ScaleIOVolumeSource represents a persistent ScaleIO volume",
+                                "properties": {
+                                    "fsType": {
+                                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+                                        "type": "string"
+                                    },
+                                    "gateway": {
+                                        "description": "The host address of the ScaleIO API Gateway.",
+                                        "type": "string"
+                                    },
+                                    "protectionDomain": {
+                                        "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                        "type": "boolean"
+                                    },
+                                    "secretRef": {
+                                        "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "sslEnabled": {
+                                        "description": "Flag to enable/disable SSL communication with Gateway, default false",
+                                        "type": "boolean"
+                                    },
+                                    "storageMode": {
+                                        "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+                                        "type": "string"
+                                    },
+                                    "storagePool": {
+                                        "description": "The ScaleIO Storage Pool associated with the protection domain.",
+                                        "type": "string"
+                                    },
+                                    "system": {
+                                        "description": "The name of the storage system as configured in ScaleIO.",
+                                        "type": "string"
+                                    },
+                                    "volumeName": {
+                                        "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "gateway",
+                                    "system",
+                                    "secretRef"
+                                ],
+                                "type": "object"
+                            },
+                            "secret": {
+                                "description": "Adapts a Secret into a volume.\n\nThe contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.",
+                                "properties": {
+                                    "defaultMode": {
+                                        "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "items": {
+                                        "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                        "items": {
+                                            "description": "Maps a string key to a path within a volume.",
+                                            "properties": {
+                                                "key": {
+                                                    "description": "The key to project.",
+                                                    "type": "string"
+                                                },
+                                                "mode": {
+                                                    "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                    "format": "int32",
+                                                    "type": "integer"
+                                                },
+                                                "path": {
+                                                    "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "key",
+                                                "path"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "optional": {
+                                        "description": "Specify whether the Secret or its keys must be defined",
+                                        "type": "boolean"
+                                    },
+                                    "secretName": {
+                                        "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "storageos": {
+                                "description": "Represents a StorageOS persistent volume resource.",
+                                "properties": {
+                                    "fsType": {
+                                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                        "type": "boolean"
+                                    },
+                                    "secretRef": {
+                                        "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "volumeName": {
+                                        "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+                                        "type": "string"
+                                    },
+                                    "volumeNamespace": {
+                                        "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "vsphereVolume": {
+                                "description": "Represents a vSphere volume resource.",
+                                "properties": {
+                                    "fsType": {
+                                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                        "type": "string"
+                                    },
+                                    "storagePolicyID": {
+                                        "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                                        "type": "string"
+                                    },
+                                    "storagePolicyName": {
+                                        "description": "Storage Policy Based Management (SPBM) profile name.",
+                                        "type": "string"
+                                    },
+                                    "volumePath": {
+                                        "description": "Path that identifies vSphere volume vmdk",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "volumePath"
+                                ],
+                                "type": "object"
+                            }
+                        },
+                        "required": [
+                            "name"
+                        ],
+                        "type": "object"
                     },
-                    "default": []
+                    "title": "Backstage container additional volumes",
+                    "type": "array"
+                },
+                "image": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "debug": {
+                            "default": false,
+                            "title": "Set to true if you would like to see extra information on logs",
+                            "type": "boolean"
+                        },
+                        "pullPolicy": {
+                            "default": "Always",
+                            "description": "Ref: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy",
+                            "enum": [
+                                "Always",
+                                "IfNotPresent"
+                            ],
+                            "title": "Specify a imagePullPolicy.",
+                            "type": "string"
+                        },
+                        "pullSecrets": {
+                            "default": [],
+                            "description": "Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/",
+                            "examples": [
+                                "myRegistryKeySecretName"
+                            ],
+                            "items": {
+                                "type": "string"
+                            },
+                            "title": "Optionally specify an array of imagePullSecrets.",
+                            "type": "array"
+                        },
+                        "registry": {
+                            "default": "ghcr.io",
+                            "examples": [
+                                "ghcr.io",
+                                "quay.io",
+                                "docker.io"
+                            ],
+                            "title": "Backstage image registry",
+                            "type": "string"
+                        },
+                        "repository": {
+                            "default": "backstage/backstage",
+                            "title": "Backstage image repository",
+                            "type": "string"
+                        },
+                        "tag": {
+                            "default": "latest",
+                            "description": "Immutable tags are recommended.",
+                            "title": "Backstage image tag",
+                            "type": "string"
+                        }
+                    },
+                    "title": "Image parameters",
+                    "type": "object"
                 },
                 "initContainers": {
-                    "title": "Backstage container init containers",
-                    "type": "array",
+                    "default": [],
                     "items": {
-                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
+                        "description": "A single application container that you want to run within a pod.",
+                        "properties": {
+                            "args": {
+                                "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "command": {
+                                "description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "env": {
+                                "description": "List of environment variables to set in the container. Cannot be updated.",
+                                "items": {
+                                    "description": "EnvVar represents an environment variable present in a Container.",
+                                    "properties": {
+                                        "name": {
+                                            "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                            "type": "string"
+                                        },
+                                        "value": {
+                                            "description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                            "type": "string"
+                                        },
+                                        "valueFrom": {
+                                            "description": "EnvVarSource represents a source for the value of an EnvVar.",
+                                            "properties": {
+                                                "configMapKeyRef": {
+                                                    "description": "Selects a key from a ConfigMap.",
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "The key to select.",
+                                                            "type": "string"
+                                                        },
+                                                        "name": {
+                                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                            "type": "string"
+                                                        },
+                                                        "optional": {
+                                                            "description": "Specify whether the ConfigMap or its key must be defined",
+                                                            "type": "boolean"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "key"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                "fieldRef": {
+                                                    "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+                                                    "properties": {
+                                                        "apiVersion": {
+                                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                            "type": "string"
+                                                        },
+                                                        "fieldPath": {
+                                                            "description": "Path of the field to select in the specified API version.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "fieldPath"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                "resourceFieldRef": {
+                                                    "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+                                                    "properties": {
+                                                        "containerName": {
+                                                            "description": "Container name: required for volumes, optional for env vars",
+                                                            "type": "string"
+                                                        },
+                                                        "divisor": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "resource": {
+                                                            "description": "Required: resource to select",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "resource"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                "secretKeyRef": {
+                                                    "description": "SecretKeySelector selects a key of a Secret.",
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                            "type": "string"
+                                                        },
+                                                        "name": {
+                                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                            "type": "string"
+                                                        },
+                                                        "optional": {
+                                                            "description": "Specify whether the Secret or its key must be defined",
+                                                            "type": "boolean"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "key"
+                                                    ],
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "required": [
+                                        "name"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-patch-merge-key": "name",
+                                "x-kubernetes-patch-strategy": "merge"
+                            },
+                            "envFrom": {
+                                "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                                "items": {
+                                    "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                                    "properties": {
+                                        "configMapRef": {
+                                            "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+                                            "properties": {
+                                                "name": {
+                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                    "type": "string"
+                                                },
+                                                "optional": {
+                                                    "description": "Specify whether the ConfigMap must be defined",
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "prefix": {
+                                            "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                            "type": "string"
+                                        },
+                                        "secretRef": {
+                                            "description": "SecretEnvSource selects a Secret to populate the environment variables with.\n\nThe contents of the target Secret's Data field will represent the key-value pairs as environment variables.",
+                                            "properties": {
+                                                "name": {
+                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                    "type": "string"
+                                                },
+                                                "optional": {
+                                                    "description": "Specify whether the Secret must be defined",
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
+                            "image": {
+                                "description": "Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                                "type": "string"
+                            },
+                            "imagePullPolicy": {
+                                "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                                "type": "string"
+                            },
+                            "lifecycle": {
+                                "description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
+                                "properties": {
+                                    "postStart": {
+                                        "description": "Handler defines a specific action that should be taken",
+                                        "properties": {
+                                            "exec": {
+                                                "description": "ExecAction describes a \"run in container\" action.",
+                                                "properties": {
+                                                    "command": {
+                                                        "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            "httpGet": {
+                                                "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                                "properties": {
+                                                    "host": {
+                                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                        "type": "string"
+                                                    },
+                                                    "httpHeaders": {
+                                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                        "items": {
+                                                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "description": "The header field name",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "description": "The header field value",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name",
+                                                                "value"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "path": {
+                                                        "description": "Path to access on the HTTP server.",
+                                                        "type": "string"
+                                                    },
+                                                    "port": {
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "integer"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "scheme": {
+                                                        "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "port"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "tcpSocket": {
+                                                "description": "TCPSocketAction describes an action based on opening a socket",
+                                                "properties": {
+                                                    "host": {
+                                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                        "type": "string"
+                                                    },
+                                                    "port": {
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "integer"
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "port"
+                                                ],
+                                                "type": "object"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "preStop": {
+                                        "description": "Handler defines a specific action that should be taken",
+                                        "properties": {
+                                            "exec": {
+                                                "description": "ExecAction describes a \"run in container\" action.",
+                                                "properties": {
+                                                    "command": {
+                                                        "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            "httpGet": {
+                                                "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                                "properties": {
+                                                    "host": {
+                                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                        "type": "string"
+                                                    },
+                                                    "httpHeaders": {
+                                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                        "items": {
+                                                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "description": "The header field name",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "description": "The header field value",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name",
+                                                                "value"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "path": {
+                                                        "description": "Path to access on the HTTP server.",
+                                                        "type": "string"
+                                                    },
+                                                    "port": {
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "integer"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "scheme": {
+                                                        "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "port"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "tcpSocket": {
+                                                "description": "TCPSocketAction describes an action based on opening a socket",
+                                                "properties": {
+                                                    "host": {
+                                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                        "type": "string"
+                                                    },
+                                                    "port": {
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "integer"
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "port"
+                                                ],
+                                                "type": "object"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "livenessProbe": {
+                                "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                                "properties": {
+                                    "exec": {
+                                        "description": "ExecAction describes a \"run in container\" action.",
+                                        "properties": {
+                                            "command": {
+                                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "failureThreshold": {
+                                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "httpGet": {
+                                        "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                        "properties": {
+                                            "host": {
+                                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                "type": "string"
+                                            },
+                                            "httpHeaders": {
+                                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                "items": {
+                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                    "properties": {
+                                                        "name": {
+                                                            "description": "The header field name",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "The header field value",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "name",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "path": {
+                                                "description": "Path to access on the HTTP server.",
+                                                "type": "string"
+                                            },
+                                            "port": {
+                                                "oneOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "integer"
+                                                    }
+                                                ]
+                                            },
+                                            "scheme": {
+                                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "port"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "initialDelaySeconds": {
+                                        "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "periodSeconds": {
+                                        "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "successThreshold": {
+                                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "tcpSocket": {
+                                        "description": "TCPSocketAction describes an action based on opening a socket",
+                                        "properties": {
+                                            "host": {
+                                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                "type": "string"
+                                            },
+                                            "port": {
+                                                "oneOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "integer"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "port"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "timeoutSeconds": {
+                                        "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "name": {
+                                "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+                                "type": "string"
+                            },
+                            "ports": {
+                                "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+                                "items": {
+                                    "description": "ContainerPort represents a network port in a single container.",
+                                    "properties": {
+                                        "containerPort": {
+                                            "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                        },
+                                        "hostIP": {
+                                            "description": "What host IP to bind the external port to.",
+                                            "type": "string"
+                                        },
+                                        "hostPort": {
+                                            "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                        },
+                                        "name": {
+                                            "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                                            "type": "string"
+                                        },
+                                        "protocol": {
+                                            "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "containerPort"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                    "containerPort",
+                                    "protocol"
+                                ],
+                                "x-kubernetes-list-type": "map",
+                                "x-kubernetes-patch-merge-key": "containerPort",
+                                "x-kubernetes-patch-strategy": "merge"
+                            },
+                            "readinessProbe": {
+                                "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                                "properties": {
+                                    "exec": {
+                                        "description": "ExecAction describes a \"run in container\" action.",
+                                        "properties": {
+                                            "command": {
+                                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "failureThreshold": {
+                                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "httpGet": {
+                                        "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                        "properties": {
+                                            "host": {
+                                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                "type": "string"
+                                            },
+                                            "httpHeaders": {
+                                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                "items": {
+                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                    "properties": {
+                                                        "name": {
+                                                            "description": "The header field name",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "The header field value",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "name",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "path": {
+                                                "description": "Path to access on the HTTP server.",
+                                                "type": "string"
+                                            },
+                                            "port": {
+                                                "oneOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "integer"
+                                                    }
+                                                ]
+                                            },
+                                            "scheme": {
+                                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "port"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "initialDelaySeconds": {
+                                        "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "periodSeconds": {
+                                        "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "successThreshold": {
+                                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "tcpSocket": {
+                                        "description": "TCPSocketAction describes an action based on opening a socket",
+                                        "properties": {
+                                            "host": {
+                                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                "type": "string"
+                                            },
+                                            "port": {
+                                                "oneOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "integer"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "port"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "timeoutSeconds": {
+                                        "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "resources": {
+                                "description": "ResourceRequirements describes the compute resource requirements.",
+                                "properties": {
+                                    "limits": {
+                                        "additionalProperties": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ]
+                                        },
+                                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                        "type": "object"
+                                    },
+                                    "requests": {
+                                        "additionalProperties": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                }
+                                            ]
+                                        },
+                                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "securityContext": {
+                                "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+                                "properties": {
+                                    "allowPrivilegeEscalation": {
+                                        "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+                                        "type": "boolean"
+                                    },
+                                    "capabilities": {
+                                        "description": "Adds and removes POSIX capabilities from running containers.",
+                                        "properties": {
+                                            "add": {
+                                                "description": "Added capabilities",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "drop": {
+                                                "description": "Removed capabilities",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "privileged": {
+                                        "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+                                        "type": "boolean"
+                                    },
+                                    "procMount": {
+                                        "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+                                        "type": "string"
+                                    },
+                                    "readOnlyRootFilesystem": {
+                                        "description": "Whether this container has a read-only root filesystem. Default is false.",
+                                        "type": "boolean"
+                                    },
+                                    "runAsGroup": {
+                                        "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                        "format": "int64",
+                                        "type": "integer"
+                                    },
+                                    "runAsNonRoot": {
+                                        "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                        "type": "boolean"
+                                    },
+                                    "runAsUser": {
+                                        "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                        "format": "int64",
+                                        "type": "integer"
+                                    },
+                                    "seLinuxOptions": {
+                                        "description": "SELinuxOptions are the labels to be applied to the container",
+                                        "properties": {
+                                            "level": {
+                                                "description": "Level is SELinux level label that applies to the container.",
+                                                "type": "string"
+                                            },
+                                            "role": {
+                                                "description": "Role is a SELinux role label that applies to the container.",
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "description": "Type is a SELinux type label that applies to the container.",
+                                                "type": "string"
+                                            },
+                                            "user": {
+                                                "description": "User is a SELinux user label that applies to the container.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "windowsOptions": {
+                                        "description": "WindowsSecurityContextOptions contain Windows-specific options and credentials.",
+                                        "properties": {
+                                            "gmsaCredentialSpec": {
+                                                "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                                "type": "string"
+                                            },
+                                            "gmsaCredentialSpecName": {
+                                                "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                                "type": "string"
+                                            },
+                                            "runAsUserName": {
+                                                "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "startupProbe": {
+                                "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                                "properties": {
+                                    "exec": {
+                                        "description": "ExecAction describes a \"run in container\" action.",
+                                        "properties": {
+                                            "command": {
+                                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "failureThreshold": {
+                                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "httpGet": {
+                                        "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                        "properties": {
+                                            "host": {
+                                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                "type": "string"
+                                            },
+                                            "httpHeaders": {
+                                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                "items": {
+                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                    "properties": {
+                                                        "name": {
+                                                            "description": "The header field name",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "The header field value",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "name",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "path": {
+                                                "description": "Path to access on the HTTP server.",
+                                                "type": "string"
+                                            },
+                                            "port": {
+                                                "oneOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "integer"
+                                                    }
+                                                ]
+                                            },
+                                            "scheme": {
+                                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "port"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "initialDelaySeconds": {
+                                        "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "periodSeconds": {
+                                        "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "successThreshold": {
+                                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "tcpSocket": {
+                                        "description": "TCPSocketAction describes an action based on opening a socket",
+                                        "properties": {
+                                            "host": {
+                                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                "type": "string"
+                                            },
+                                            "port": {
+                                                "oneOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "integer"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "port"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "timeoutSeconds": {
+                                        "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                        "format": "int32",
+                                        "type": "integer"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "stdin": {
+                                "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                                "type": "boolean"
+                            },
+                            "stdinOnce": {
+                                "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                                "type": "boolean"
+                            },
+                            "terminationMessagePath": {
+                                "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                                "type": "string"
+                            },
+                            "terminationMessagePolicy": {
+                                "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+                                "type": "string"
+                            },
+                            "tty": {
+                                "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                                "type": "boolean"
+                            },
+                            "volumeDevices": {
+                                "description": "volumeDevices is the list of block devices to be used by the container.",
+                                "items": {
+                                    "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                                    "properties": {
+                                        "devicePath": {
+                                            "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "description": "name must match the name of a persistentVolumeClaim in the pod",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "name",
+                                        "devicePath"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-patch-merge-key": "devicePath",
+                                "x-kubernetes-patch-strategy": "merge"
+                            },
+                            "volumeMounts": {
+                                "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+                                "items": {
+                                    "description": "VolumeMount describes a mounting of a Volume within a container.",
+                                    "properties": {
+                                        "mountPath": {
+                                            "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                                            "type": "string"
+                                        },
+                                        "mountPropagation": {
+                                            "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "description": "This must match the Name of a Volume.",
+                                            "type": "string"
+                                        },
+                                        "readOnly": {
+                                            "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                                            "type": "boolean"
+                                        },
+                                        "subPath": {
+                                            "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                                            "type": "string"
+                                        },
+                                        "subPathExpr": {
+                                            "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "name",
+                                        "mountPath"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-patch-merge-key": "mountPath",
+                                "x-kubernetes-patch-strategy": "merge"
+                            },
+                            "workingDir": {
+                                "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name"
+                        ],
+                        "type": "object"
                     },
-                    "default": []
+                    "title": "Backstage container init containers",
+                    "type": "array"
                 },
                 "installDir": {
+                    "default": "/app",
                     "title": "Directory containing the backstage installation",
-                    "type": "string",
-                    "default": "/app"
-                },
-                "resources": {
-                    "title": "Resource requests/limits",
-                    "description": "Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container",
-                    "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
-                    "default": {},
-                    "examples": [
-                        {
-                            "limits": {
-                                "memory": "1Gi",
-                                "cpu": "1000m"
-                            },
-                            "requests": {
-                                "memory": "250Mi",
-                                "cpu": "100m"
-                            }
-                        }
-                    ]
-                },
-                "readinessProbe": {
-                    "title": "Readiness probe",
-                    "description": "Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/",
-                    "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
-                    "default": {},
-                    "examples": [
-                        {
-                            "failureThreshold": 3,
-                            "httpGet": {
-                                "path": "/healthcheck",
-                                "port": 7007,
-                                "scheme": "HTTP"
-                            },
-                            "initialDelaySeconds": 30,
-                            "periodSeconds": 10,
-                            "successThreshold": 2,
-                            "timeoutSeconds": 2
-                        }
-                    ]
+                    "type": "string"
                 },
                 "livenessProbe": {
-                    "title": "Liveness probe",
-                    "description": "Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/",
-                    "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
-                    "default": {},
-                    "examples": [
-                        {
-                            "failureThreshold": 3,
-                            "httpGet": {
-                                "path": "/healthcheck",
-                                "port": 7007,
-                                "scheme": "HTTP"
+                    "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                    "properties": {
+                        "exec": {
+                            "description": "ExecAction describes a \"run in container\" action.",
+                            "properties": {
+                                "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                }
                             },
-                            "initialDelaySeconds": 60,
-                            "periodSeconds": 10,
-                            "successThreshold": 1,
-                            "timeoutSeconds": 2
-                        }
-                    ]
-                },
-                "startupProbe": {
-                    "title": "Startup probe",
-                    "description": "Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/",
-                    "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
-                    "default": {},
-                    "examples": [
-                        {
-                            "failureThreshold": 3,
-                            "httpGet": {
-                                "path": "/healthcheck",
-                                "port": 7007,
-                                "scheme": "HTTP"
+                            "type": "object"
+                        },
+                        "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "format": "int32",
+                            "type": "integer"
+                        },
+                        "httpGet": {
+                            "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                            "properties": {
+                                "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": "string"
+                                },
+                                "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "items": {
+                                        "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                        "properties": {
+                                            "name": {
+                                                "description": "The header field name",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The header field value",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "value"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                },
+                                "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "oneOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "integer"
+                                        }
+                                    ]
+                                },
+                                "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                    "type": "string"
+                                }
                             },
-                            "initialDelaySeconds": 60,
-                            "periodSeconds": 10,
-                            "successThreshold": 1,
-                            "timeoutSeconds": 2
+                            "required": [
+                                "port"
+                            ],
+                            "type": "object"
+                        },
+                        "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "format": "int32",
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "format": "int32",
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "format": "int32",
+                            "type": "integer"
+                        },
+                        "tcpSocket": {
+                            "description": "TCPSocketAction describes an action based on opening a socket",
+                            "properties": {
+                                "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "oneOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "integer"
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "port"
+                            ],
+                            "type": "object"
+                        },
+                        "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "format": "int32",
+                            "type": "integer"
                         }
-                    ]
-                },
-                "podSecurityContext": {
-                    "title": "Security settings for a Pod.",
-                    "description": "The security settings that you specify for a Pod apply to all Containers in the Pod. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod",
-                    "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
-                    "default": {}
-                },
-                "containerSecurityContext": {
-                    "title": "Security settings for a Container.",
-                    "description": "Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container",
-                    "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
-                    "default": {}
-                },
-                "appConfig": {
-                    "title": "Generates ConfigMap and configures it in the Backstage pods",
-                    "type": [
-                        "object",
-                        "string"
-                    ],
-                    "default": {},
-                    "examples": [
-                        {
-                            "app": {
-                                "baseUrl": "https://somedomain.tld"
-                            }
-                        }
-                    ]
+                    },
+                    "type": "object"
                 },
                 "nodeSelector": {
-                    "title": "Node labels for pod assignment",
-                    "description": "Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector",
-                    "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "default": {}
-                },
-                "tolerations": {
-                    "title": "Node tolerations for server scheduling to nodes with taints",
-                    "description": "Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/",
-                    "type": "array",
-                    "items": {
-                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Toleration"
-                    },
-                    "default": []
+                    "default": {},
+                    "description": "Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector",
+                    "title": "Node labels for pod assignment",
+                    "type": "object"
                 },
                 "podAnnotations": {
-                    "title": "Annotations to add to the backend deployment pods",
-                    "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "default": {}
+                    "default": {},
+                    "title": "Annotations to add to the backend deployment pods",
+                    "type": "object"
                 },
                 "podLabels": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {},
                     "title": "Labels to add to the backend deployment pods",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "default": {}
+                    "type": "object"
                 },
-                "annotations": {
-                    "title": "Additional custom annotations for the `Deployment` resource",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
+                "podSecurityContext": {
+                    "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+                    "properties": {
+                        "allowPrivilegeEscalation": {
+                            "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+                            "type": "boolean"
+                        },
+                        "capabilities": {
+                            "description": "Adds and removes POSIX capabilities from running containers.",
+                            "properties": {
+                                "add": {
+                                    "description": "Added capabilities",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                "drop": {
+                                    "description": "Removed capabilities",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "privileged": {
+                            "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+                            "type": "boolean"
+                        },
+                        "procMount": {
+                            "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+                            "type": "string"
+                        },
+                        "readOnlyRootFilesystem": {
+                            "description": "Whether this container has a read-only root filesystem. Default is false.",
+                            "type": "boolean"
+                        },
+                        "runAsGroup": {
+                            "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "format": "int64",
+                            "type": "integer"
+                        },
+                        "runAsNonRoot": {
+                            "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": "boolean"
+                        },
+                        "runAsUser": {
+                            "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "format": "int64",
+                            "type": "integer"
+                        },
+                        "seLinuxOptions": {
+                            "description": "SELinuxOptions are the labels to be applied to the container",
+                            "properties": {
+                                "level": {
+                                    "description": "Level is SELinux level label that applies to the container.",
+                                    "type": "string"
+                                },
+                                "role": {
+                                    "description": "Role is a SELinux role label that applies to the container.",
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "description": "Type is a SELinux type label that applies to the container.",
+                                    "type": "string"
+                                },
+                                "user": {
+                                    "description": "User is a SELinux user label that applies to the container.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "windowsOptions": {
+                            "description": "WindowsSecurityContextOptions contain Windows-specific options and credentials.",
+                            "properties": {
+                                "gmsaCredentialSpec": {
+                                    "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                    "type": "string"
+                                },
+                                "gmsaCredentialSpecName": {
+                                    "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                    "type": "string"
+                                },
+                                "runAsUserName": {
+                                    "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
                     },
-                    "default": {}
+                    "type": "object"
+                },
+                "readinessProbe": {
+                    "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                    "properties": {
+                        "exec": {
+                            "description": "ExecAction describes a \"run in container\" action.",
+                            "properties": {
+                                "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "format": "int32",
+                            "type": "integer"
+                        },
+                        "httpGet": {
+                            "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                            "properties": {
+                                "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": "string"
+                                },
+                                "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "items": {
+                                        "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                        "properties": {
+                                            "name": {
+                                                "description": "The header field name",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The header field value",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "value"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                },
+                                "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "oneOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "integer"
+                                        }
+                                    ]
+                                },
+                                "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "port"
+                            ],
+                            "type": "object"
+                        },
+                        "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "format": "int32",
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "format": "int32",
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "format": "int32",
+                            "type": "integer"
+                        },
+                        "tcpSocket": {
+                            "description": "TCPSocketAction describes an action based on opening a socket",
+                            "properties": {
+                                "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "oneOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "integer"
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "port"
+                            ],
+                            "type": "object"
+                        },
+                        "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    },
+                    "type": "object"
+                },
+                "replicas": {
+                    "default": 1,
+                    "minimum": 0,
+                    "title": "Number of deployment replicas",
+                    "type": "integer"
+                },
+                "resources": {
+                    "description": "ResourceRequirements describes the compute resource requirements.",
+                    "properties": {
+                        "limits": {
+                            "additionalProperties": {
+                                "oneOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "number"
+                                    }
+                                ]
+                            },
+                            "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                            "type": "object"
+                        },
+                        "requests": {
+                            "additionalProperties": {
+                                "oneOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "number"
+                                    }
+                                ]
+                            },
+                            "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "revisionHistoryLimit": {
+                    "default": 10,
+                    "minimum": 0,
+                    "title": "The count of deployment revisions",
+                    "type": "integer"
+                },
+                "startupProbe": {
+                    "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                    "properties": {
+                        "exec": {
+                            "description": "ExecAction describes a \"run in container\" action.",
+                            "properties": {
+                                "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "format": "int32",
+                            "type": "integer"
+                        },
+                        "httpGet": {
+                            "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                            "properties": {
+                                "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": "string"
+                                },
+                                "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "items": {
+                                        "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                        "properties": {
+                                            "name": {
+                                                "description": "The header field name",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The header field value",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "value"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                },
+                                "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "oneOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "integer"
+                                        }
+                                    ]
+                                },
+                                "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "port"
+                            ],
+                            "type": "object"
+                        },
+                        "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "format": "int32",
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "format": "int32",
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "format": "int32",
+                            "type": "integer"
+                        },
+                        "tcpSocket": {
+                            "description": "TCPSocketAction describes an action based on opening a socket",
+                            "properties": {
+                                "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "oneOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "integer"
+                                        }
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "port"
+                            ],
+                            "type": "object"
+                        },
+                        "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tolerations": {
+                    "default": [],
+                    "description": "Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/",
+                    "items": {
+                        "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                        "properties": {
+                            "effect": {
+                                "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                "type": "string"
+                            },
+                            "key": {
+                                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                "type": "string"
+                            },
+                            "operator": {
+                                "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                "type": "string"
+                            },
+                            "tolerationSeconds": {
+                                "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                "format": "int64",
+                                "type": "integer"
+                            },
+                            "value": {
+                                "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "title": "Node tolerations for server scheduling to nodes with taints",
+                    "type": "array"
                 }
-            }
+            },
+            "title": "Backstage parameters",
+            "type": "object"
         },
-        "service": {
-            "title": "Service parameters",
-            "type": "object",
+        "clusterDomain": {
+            "default": "cluster.local",
+            "title": "Default Kubernetes cluster domain",
+            "type": "string"
+        },
+        "commonAnnotations": {
+            "additionalProperties": {
+                "type": "string"
+            },
+            "default": {},
+            "title": "Annotations to add to all deployed objects",
+            "type": "object"
+        },
+        "commonLabels": {
+            "additionalProperties": {
+                "type": "string"
+            },
+            "default": {},
+            "title": "Labels to add to all deployed objects",
+            "type": "object"
+        },
+        "diagnosticMode": {
             "additionalProperties": false,
             "properties": {
+                "args": {
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "Args to override all containers in the Deployment",
+                    "type": "array"
+                },
+                "command": {
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "Command to override all containers in the Deployment",
+                    "type": "array"
+                },
+                "enabled": {
+                    "default": false,
+                    "description": "All probes will be disabled and the command will be overridden",
+                    "title": "Enable diagnostic mode",
+                    "type": "boolean"
+                }
+            },
+            "title": "Enable diagnostic mode in the Deployment",
+            "type": "object"
+        },
+        "extraDeploy": {
+            "default": [],
+            "items": {
+                "type": [
+                    "string",
+                    "object"
+                ]
+            },
+            "title": "Array of extra objects to deploy with the release",
+            "type": "array",
+            "uniqueItems": true
+        },
+        "fullnameOverride": {
+            "default": "",
+            "title": "String to fully override common.names.fullname",
+            "type": "string"
+        },
+        "global": {
+            "properties": {
+                "imagePullSecrets": {
+                    "default": [],
+                    "examples": [
+                        [
+                            "myRegistryKeySecretName"
+                        ]
+                    ],
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "Global Docker registry secret names as an array",
+                    "type": "array",
+                    "uniqueItems": true
+                },
+                "imageRegistry": {
+                    "default": "",
+                    "title": "Global Docker image registry",
+                    "type": "string"
+                }
+            },
+            "title": "Global parameters.",
+            "type": "object"
+        },
+        "ingress": {
+            "additionalProperties": false,
+            "properties": {
+                "annotations": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {},
+                    "title": "Additional annotations for the Ingress resource",
+                    "type": "object"
+                },
+                "className": {
+                    "default": "",
+                    "examples": [
+                        "nginx"
+                    ],
+                    "title": "Name of the IngressClass cluster resource which defines which controller will implement the resource.",
+                    "type": "string"
+                },
+                "enabled": {
+                    "default": false,
+                    "title": "Enable the creation of the ingress resource",
+                    "type": "boolean"
+                },
+                "host": {
+                    "default": "",
+                    "examples": [
+                        "backstage.10.0.0.1.nip.io"
+                    ],
+                    "title": "Hostname to be used to expose the route to access the backstage application.",
+                    "type": "string"
+                },
+                "tls": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "default": false,
+                            "description": "TLS for the host defined at `ingress.host` parameter",
+                            "title": "Enable TLS configuration",
+                            "type": "boolean"
+                        },
+                        "secretName": {
+                            "default": "",
+                            "title": "The name to which the TLS Secret will be called",
+                            "type": "string"
+                        }
+                    },
+                    "title": "Ingress TLS parameters",
+                    "type": "object"
+                }
+            },
+            "title": "Ingress parameters",
+            "type": "object"
+        },
+        "kubeVersion": {
+            "default": "",
+            "title": "Override Kubernetes version",
+            "type": "string"
+        },
+        "metrics": {
+            "additionalProperties": false,
+            "description": "Allows configuring your backstage instance as a scrape target for Prometheus. Ref: https://github.com/prometheus/prometheus",
+            "properties": {
+                "serviceMonitor": {
+                    "additionalProperties": false,
+                    "description": "A custom resource that is consumed by Prometheus Operator. Ref: https://github.com/prometheus-operator/prometheus-operator",
+                    "properties": {
+                        "annotations": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "default": {},
+                            "title": "ServiceMonitor annotations",
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "default": false,
+                            "description": "Prometheus Operator must be installed in your cluster prior to enabling.",
+                            "title": "If enabled, a ServiceMonitor resource for Prometheus Operator is created",
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "default": null,
+                            "title": "ServiceMonitor scrape interval",
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "labels": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "default": {},
+                            "title": "Additional ServiceMonitor labels",
+                            "type": "object"
+                        },
+                        "path": {
+                            "default": "/metrics",
+                            "description": "ote that the /metrics endpoint is NOT present in a freshly scaffolded Backstage app. To setup, follow the Prometheus metrics tutorial. https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/prometheus-metrics.md",
+                            "title": "ServiceMonitor endpoint path",
+                            "type": "string"
+                        }
+                    },
+                    "title": "ServiceMonitor configuration",
+                    "type": "object"
+                }
+            },
+            "title": "Metrics configuration",
+            "type": "object"
+        },
+        "nameOverride": {
+            "default": "",
+            "title": "String to partially override common.names.fullname",
+            "type": "string"
+        },
+        "networkPolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "egressRules": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "customRules": {
+                            "items": {
+                                "description": "NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to. This type is beta-level in 1.8",
+                                "properties": {
+                                    "ports": {
+                                        "description": "List of destination ports for outgoing traffic. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.",
+                                        "items": {
+                                            "description": "NetworkPolicyPort describes a port to allow traffic on",
+                                            "properties": {
+                                                "port": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "integer"
+                                                        }
+                                                    ]
+                                                },
+                                                "protocol": {
+                                                    "description": "The protocol (TCP or UDP) which traffic must match. If not specified, this field defaults to TCP.",
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "type": "array"
+                                    },
+                                    "to": {
+                                        "description": "List of destinations for outgoing traffic of pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all destinations (traffic not restricted by destination). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the to list.",
+                                        "items": {
+                                            "description": "NetworkPolicyPeer describes a peer to allow traffic from. Exactly one of its fields must be specified.",
+                                            "properties": {
+                                                "ipBlock": {
+                                                    "description": "IPBlock describes a particular CIDR (Ex. \"192.168.1.1/24\") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.",
+                                                    "properties": {
+                                                        "cidr": {
+                                                            "description": "CIDR is a string representing the IP Block Valid examples are \"192.168.1.1/24\"",
+                                                            "type": "string"
+                                                        },
+                                                        "except": {
+                                                            "description": "Except is a slice of CIDRs that should not be included within an IP Block Valid examples are \"192.168.1.1/24\" Except values will be rejected if they are outside the CIDR range",
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "cidr"
+                                                    ]
+                                                },
+                                                "namespaceSelector": {
+                                                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                                    "properties": {
+                                                        "matchExpressions": {
+                                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                            "items": {
+                                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                "properties": {
+                                                                    "key": {
+                                                                        "description": "key is the label key that the selector applies to.",
+                                                                        "type": "string",
+                                                                        "x-kubernetes-patch-merge-key": "key",
+                                                                        "x-kubernetes-patch-strategy": "merge"
+                                                                    },
+                                                                    "operator": {
+                                                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "values": {
+                                                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "key",
+                                                                    "operator"
+                                                                ]
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        "matchLabels": {
+                                                            "additionalProperties": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                            "type": "object"
+                                                        }
+                                                    }
+                                                },
+                                                "podSelector": {
+                                                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                                    "properties": {
+                                                        "matchExpressions": {
+                                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                            "items": {
+                                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                "properties": {
+                                                                    "key": {
+                                                                        "description": "key is the label key that the selector applies to.",
+                                                                        "type": "string",
+                                                                        "x-kubernetes-patch-merge-key": "key",
+                                                                        "x-kubernetes-patch-strategy": "merge"
+                                                                    },
+                                                                    "operator": {
+                                                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "values": {
+                                                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "key",
+                                                                    "operator"
+                                                                ]
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        "matchLabels": {
+                                                            "additionalProperties": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                            "type": "object"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "type": "array"
+                                    }
+                                }
+                            },
+                            "title": "",
+                            "type": "array"
+                        },
+                        "denyConnectionsToExternal": {
+                            "default": false,
+                            "title": "Deny external connections. Should not be enabled when working with an external database.",
+                            "type": "boolean"
+                        }
+                    },
+                    "title": "Custom egress rules for the network policy",
+                    "type": "object"
+                },
+                "enabled": {
+                    "default": false,
+                    "title": "Specifies whether a NetworkPolicy should be created",
+                    "type": "boolean"
+                },
+                "ingressRules": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "customRules": {
+                            "items": {
+                                "description": "NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.",
+                                "properties": {
+                                    "from": {
+                                        "description": "List of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all sources (traffic not restricted by source). If this field is present and contains at least on item, this rule allows traffic only if the traffic matches at least one item in the from list.",
+                                        "items": {
+                                            "description": "NetworkPolicyPeer describes a peer to allow traffic from. Exactly one of its fields must be specified.",
+                                            "properties": {
+                                                "ipBlock": {
+                                                    "description": "IPBlock describes a particular CIDR (Ex. \"192.168.1.1/24\") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.",
+                                                    "properties": {
+                                                        "cidr": {
+                                                            "description": "CIDR is a string representing the IP Block Valid examples are \"192.168.1.1/24\"",
+                                                            "type": "string"
+                                                        },
+                                                        "except": {
+                                                            "description": "Except is a slice of CIDRs that should not be included within an IP Block Valid examples are \"192.168.1.1/24\" Except values will be rejected if they are outside the CIDR range",
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "cidr"
+                                                    ]
+                                                },
+                                                "namespaceSelector": {
+                                                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                                    "properties": {
+                                                        "matchExpressions": {
+                                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                            "items": {
+                                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                "properties": {
+                                                                    "key": {
+                                                                        "description": "key is the label key that the selector applies to.",
+                                                                        "type": "string",
+                                                                        "x-kubernetes-patch-merge-key": "key",
+                                                                        "x-kubernetes-patch-strategy": "merge"
+                                                                    },
+                                                                    "operator": {
+                                                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "values": {
+                                                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "key",
+                                                                    "operator"
+                                                                ]
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        "matchLabels": {
+                                                            "additionalProperties": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                            "type": "object"
+                                                        }
+                                                    }
+                                                },
+                                                "podSelector": {
+                                                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                                    "properties": {
+                                                        "matchExpressions": {
+                                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                            "items": {
+                                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                "properties": {
+                                                                    "key": {
+                                                                        "description": "key is the label key that the selector applies to.",
+                                                                        "type": "string",
+                                                                        "x-kubernetes-patch-merge-key": "key",
+                                                                        "x-kubernetes-patch-strategy": "merge"
+                                                                    },
+                                                                    "operator": {
+                                                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "values": {
+                                                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "key",
+                                                                    "operator"
+                                                                ]
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        "matchLabels": {
+                                                            "additionalProperties": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                            "type": "object"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "type": "array"
+                                    },
+                                    "ports": {
+                                        "description": "List of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.",
+                                        "items": {
+                                            "description": "NetworkPolicyPort describes a port to allow traffic on",
+                                            "properties": {
+                                                "port": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "integer"
+                                                        }
+                                                    ]
+                                                },
+                                                "protocol": {
+                                                    "description": "The protocol (TCP or UDP) which traffic must match. If not specified, this field defaults to TCP.",
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "type": "array"
+                                    }
+                                }
+                            },
+                            "title": "",
+                            "type": "array"
+                        },
+                        "namespaceSelector": {
+                            "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                            "properties": {
+                                "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                        "properties": {
+                                            "key": {
+                                                "description": "key is the label key that the selector applies to.",
+                                                "type": "string",
+                                                "x-kubernetes-patch-merge-key": "key",
+                                                "x-kubernetes-patch-strategy": "merge"
+                                            },
+                                            "operator": {
+                                                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                "type": "string"
+                                            },
+                                            "values": {
+                                                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "key",
+                                            "operator"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                },
+                                "matchLabels": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "podSelector": {
+                            "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                            "properties": {
+                                "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                        "properties": {
+                                            "key": {
+                                                "description": "key is the label key that the selector applies to.",
+                                                "type": "string",
+                                                "x-kubernetes-patch-merge-key": "key",
+                                                "x-kubernetes-patch-strategy": "merge"
+                                            },
+                                            "operator": {
+                                                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                "type": "string"
+                                            },
+                                            "values": {
+                                                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "key",
+                                            "operator"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                },
+                                "matchLabels": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "title": "Custom egress rules for the network policy",
+                    "type": "object"
+                }
+            },
+            "title": "Network policies",
+            "type": "object"
+        },
+        "postgresql": {
+            "$schema": "http://json-schema.org/schema#",
+            "properties": {
+                "architecture": {
+                    "description": "Allowed values: `standalone` or `replication`",
+                    "form": true,
+                    "title": "PostgreSQL architecture",
+                    "type": "string"
+                },
+                "auth": {
+                    "form": true,
+                    "properties": {
+                        "database": {
+                            "description": "Name of the custom database to be created during the 1st initialization of PostgreSQL",
+                            "form": true,
+                            "title": "PostgreSQL custom database",
+                            "type": "string"
+                        },
+                        "enablePostgresUser": {
+                            "description": "Assign a password to the \"postgres\" admin user. Otherwise, remote access will be blocked for this user",
+                            "form": true,
+                            "title": "Enable \"postgres\" admin user",
+                            "type": "boolean"
+                        },
+                        "password": {
+                            "description": "Defaults to a random 10-character alphanumeric string if not set",
+                            "form": true,
+                            "title": "Password for the custom user to create",
+                            "type": "string"
+                        },
+                        "postgresPassword": {
+                            "description": "Defaults to a random 10-character alphanumeric string if not set",
+                            "form": true,
+                            "title": "Password for the \"postgres\" admin user",
+                            "type": "string"
+                        },
+                        "replicationPassword": {
+                            "description": "Defaults to a random 10-character alphanumeric string if not set",
+                            "form": true,
+                            "hidden": {
+                                "path": "architecture",
+                                "value": "standalone"
+                            },
+                            "title": "Password for PostgreSQL replication user",
+                            "type": "string"
+                        },
+                        "replicationUsername": {
+                            "description": "Name of user used to manage replication.",
+                            "form": true,
+                            "hidden": {
+                                "path": "architecture",
+                                "value": "standalone"
+                            },
+                            "title": "PostgreSQL replication user",
+                            "type": "string"
+                        },
+                        "username": {
+                            "description": "Name of the custom user to be created during the 1st initialization of PostgreSQL. This user only has permissions on the PostgreSQL custom database",
+                            "form": true,
+                            "title": "PostgreSQL custom user",
+                            "type": "string"
+                        }
+                    },
+                    "title": "Authentication configuration",
+                    "type": "object"
+                },
+                "metrics": {
+                    "properties": {
+                        "enabled": {
+                            "form": true,
+                            "title": "Configure metrics exporter",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                },
+                "persistence": {
+                    "properties": {
+                        "size": {
+                            "form": true,
+                            "render": "slider",
+                            "sliderMax": 100,
+                            "sliderMin": 1,
+                            "sliderUnit": "Gi",
+                            "title": "Persistent Volume Size",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "replication": {
+                    "form": true,
+                    "properties": {
+                        "enabled": {
+                            "form": true,
+                            "title": "Enable Replication",
+                            "type": "boolean"
+                        },
+                        "readReplicas": {
+                            "form": true,
+                            "hidden": {
+                                "path": "architecture",
+                                "value": "standalone"
+                            },
+                            "title": "read Replicas",
+                            "type": "integer"
+                        }
+                    },
+                    "title": "Replication Details",
+                    "type": "object"
+                },
+                "resources": {
+                    "description": "Configure resource requests",
+                    "form": true,
+                    "properties": {
+                        "requests": {
+                            "properties": {
+                                "cpu": {
+                                    "form": true,
+                                    "render": "slider",
+                                    "sliderMax": 2000,
+                                    "sliderMin": 10,
+                                    "sliderUnit": "m",
+                                    "title": "CPU Request",
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "form": true,
+                                    "render": "slider",
+                                    "sliderMax": 2048,
+                                    "sliderMin": 10,
+                                    "sliderUnit": "Mi",
+                                    "title": "Memory Request",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "title": "Required Resources",
+                    "type": "object"
+                },
+                "volumePermissions": {
+                    "properties": {
+                        "enabled": {
+                            "description": "Change the owner of the persist volume mountpoint to RunAsUser:fsGroup",
+                            "form": true,
+                            "title": "Enable Init Containers",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "service": {
+            "additionalProperties": false,
+            "properties": {
+                "annotations": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {},
+                    "title": "Additional custom annotations for Backstage service",
+                    "type": "object"
+                },
+                "clusterIP": {
+                    "default": "",
+                    "title": "Backstage service Cluster IP",
+                    "type": "string"
+                },
+                "externalTrafficPolicy": {
+                    "default": "Cluster",
+                    "description": "Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip",
+                    "enum": [
+                        "Cluster",
+                        "Local"
+                    ],
+                    "title": "Backstage service external traffic policy",
+                    "type": "string"
+                },
+                "extraPorts": {
+                    "default": [],
+                    "items": {
+                        "type": "object"
+                    },
+                    "title": "Extra ports to expose in the Backstage service",
+                    "type": "array"
+                },
+                "loadBalancerIP": {
+                    "default": "",
+                    "description": "Ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer",
+                    "title": "Backstage service Load Balancer IP",
+                    "type": "string"
+                },
+                "loadBalancerSourceRanges": {
+                    "default": [],
+                    "description": "Ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer",
+                    "examples": [
+                        "10.10.10.0/24"
+                    ],
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "Load Balancer sources",
+                    "type": "array"
+                },
+                "nodePorts": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "backend": {
+                            "default": "",
+                            "maximum": 32767,
+                            "minimum": 30000,
+                            "title": "Node port for backend",
+                            "type": [
+                                "string",
+                                "integer"
+                            ]
+                        }
+                    },
+                    "title": "Node port for the Backstage client connections",
+                    "type": "object"
+                },
+                "ports": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "backend": {
+                            "default": 7007,
+                            "title": "Backstage svc port number",
+                            "type": "integer"
+                        },
+                        "name": {
+                            "default": "http-backend",
+                            "title": "Backstage svc port name",
+                            "type": "string"
+                        },
+                        "targetPort": {
+                            "default": "backend",
+                            "title": "Backstage svc target port referencing receiving pod container port",
+                            "type": "string"
+                        }
+                    },
+                    "title": "Backstage svc port for client connections",
+                    "type": "object"
+                },
+                "sessionAffinity": {
+                    "default": "None",
+                    "description": "Ref: https://kubernetes.io/docs/concepts/services-networking/service/#session-stickiness",
+                    "enum": [
+                        "None",
+                        "ClientIP"
+                    ],
+                    "title": "Control where client requests go, to the same pod or round-robin",
+                    "type": "string"
+                },
                 "type": {
-                    "title": "Kubernetes Service type",
-                    "type": "string",
                     "default": "ClusterIP",
                     "enum": [
                         "ClusterIP",
                         "NodePort",
                         "LoadBalancer",
                         "ExternalName"
-                    ]
-                },
-                "ports": {
-                    "title": "Backstage svc port for client connections",
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "backend": {
-                            "title": "Backstage svc port number",
-                            "type": "integer",
-                            "default": 7007
-                        },
-                        "name": {
-                            "title": "Backstage svc port name",
-                            "type": "string",
-                            "default": "http-backend"
-                        },
-                        "targetPort": {
-                            "title": "Backstage svc target port referencing receiving pod container port",
-                            "type": "string",
-                            "default": "backend"
-                        }
-                    }
-                },
-                "nodePorts": {
-                    "title": "Node port for the Backstage client connections",
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "backend": {
-                            "title": "Node port for backend",
-                            "type": [
-                                "string",
-                                "integer"
-                            ],
-                            "default": "",
-                            "minimum": 30000,
-                            "maximum": 32767
-                        }
-                    }
-                },
-                "sessionAffinity": {
-                    "title": "Control where client requests go, to the same pod or round-robin",
-                    "description": "Ref: https://kubernetes.io/docs/concepts/services-networking/service/#session-stickiness",
-                    "type": "string",
-                    "default": "None",
-                    "enum": [
-                        "None",
-                        "ClientIP"
-                    ]
-                },
-                "clusterIP": {
-                    "title": "Backstage service Cluster IP",
-                    "type": "string",
-                    "default": ""
-                },
-                "loadBalancerIP": {
-                    "title": "Backstage service Load Balancer IP",
-                    "description": "Ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer",
-                    "type": "string",
-                    "default": ""
-                },
-                "loadBalancerSourceRanges": {
-                    "title": "Load Balancer sources",
-                    "description": "Ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [],
-                    "examples": [
-                        "10.10.10.0/24"
-                    ]
-                },
-                "externalTrafficPolicy": {
-                    "title": "Backstage service external traffic policy",
-                    "description": "Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip",
-                    "type": "string",
-                    "default": "Cluster",
-                    "enum": [
-                        "Cluster",
-                        "Local"
-                    ]
-                },
-                "annotations": {
-                    "title": "Additional custom annotations for Backstage service",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "default": {}
-                },
-                "extraPorts": {
-                    "title": "Extra ports to expose in the Backstage service",
-                    "type": "array",
-                    "items": {
-                        "type": "object"
-                    },
-                    "default": []
+                    ],
+                    "title": "Kubernetes Service type",
+                    "type": "string"
                 }
-            }
-        },
-        "networkPolicy": {
-            "title": "Network policies",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "enabled": {
-                    "title": "Specifies whether a NetworkPolicy should be created",
-                    "type": "boolean",
-                    "default": false
-                },
-                "ingressRules": {
-                    "title": "Custom egress rules for the network policy",
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "customRules": {
-                            "title": "",
-                            "type": "array",
-                            "items": {
-                                "$ref": "https://kubernetesjsonschema.dev/v1.8.7/_definitions.json#/definitions/io.k8s.api.networking.v1.NetworkPolicyIngressRule"
-                            }
-                        },
-                        "namespaceSelector": {
-                            "title": "Namespace Selector.",
-                            "description": "Selects Namespaces using cluster scoped-labels.",
-                            "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
-                            "default": {}
-                        },
-                        "podSelector": {
-                            "title": "Pod Selector.",
-                            "description": "Selects selects Pods in this namespace.",
-                            "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
-                            "default": {}
-                        }
-                    }
-                },
-                "egressRules": {
-                    "title": "Custom egress rules for the network policy",
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "customRules": {
-                            "title": "",
-                            "type": "array",
-                            "items": {
-                                "$ref": "https://kubernetesjsonschema.dev/v1.8.7/_definitions.json#/definitions/io.k8s.api.networking.v1.NetworkPolicyEgressRule"
-                            }
-                        },
-                        "denyConnectionsToExternal": {
-                            "title": "Deny external connections. Should not be enabled when working with an external database.",
-                            "type": "boolean",
-                            "default": false
-                        }
-                    }
-                }
-            }
-        },
-        "postgresql": {
-            "title": "PostgreSQL chart configuration",
-            "description": "Ref. https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml",
-            "$ref": "https://raw.githubusercontent.com/bitnami/charts/main/bitnami/postgresql/values.schema.json"
+            },
+            "title": "Service parameters",
+            "type": "object"
         },
         "serviceAccount": {
-            "title": "Service Account Configuration",
-            "type": "object",
             "additionalProperties": false,
             "properties": {
-                "create": {
-                    "title": "Enable the creation of a ServiceAccount for Backstage pods",
-                    "type": "boolean",
-                    "default": false
-                },
-                "name": {
-                    "title": "Name of the ServiceAccount to use",
-                    "description": "If not set and `serviceAccount.create` is true, a name is generated",
-                    "type": "string",
-                    "default": ""
-                },
-                "labels": {
-                    "title": "Additional custom labels to the service ServiceAccount.",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "default": {}
-                },
                 "annotations": {
-                    "title": "Additional custom annotations for the ServiceAccount.",
-                    "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "default": {}
+                    "default": {},
+                    "title": "Additional custom annotations for the ServiceAccount.",
+                    "type": "object"
                 },
                 "automountServiceAccountToken": {
+                    "default": true,
                     "title": "Auto-mount the service account token in the pod",
-                    "type": "boolean",
-                    "default": true
+                    "type": "boolean"
+                },
+                "create": {
+                    "default": false,
+                    "title": "Enable the creation of a ServiceAccount for Backstage pods",
+                    "type": "boolean"
+                },
+                "labels": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {},
+                    "title": "Additional custom labels to the service ServiceAccount.",
+                    "type": "object"
+                },
+                "name": {
+                    "default": "",
+                    "description": "If not set and `serviceAccount.create` is true, a name is generated",
+                    "title": "Name of the ServiceAccount to use",
+                    "type": "string"
                 }
-            }
-        },
-        "metrics": {
-            "title": "Metrics configuration",
-            "description": "Allows configuring your backstage instance as a scrape target for Prometheus. Ref: https://github.com/prometheus/prometheus",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "serviceMonitor": {
-                    "title": "ServiceMonitor configuration",
-                    "description": "A custom resource that is consumed by Prometheus Operator. Ref: https://github.com/prometheus-operator/prometheus-operator",
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "enabled": {
-                            "title": "If enabled, a ServiceMonitor resource for Prometheus Operator is created",
-                            "description": "Prometheus Operator must be installed in your cluster prior to enabling.",
-                            "type": "boolean",
-                            "default": false
-                        },
-                        "annotations": {
-                            "title": "ServiceMonitor annotations",
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            },
-                            "default": {}
-                        },
-                        "labels": {
-                            "title": "Additional ServiceMonitor labels",
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            },
-                            "default": {}
-                        },
-                        "interval": {
-                            "title": "ServiceMonitor scrape interval",
-                            "type": [
-                                "string",
-                                "null"
-                            ],
-                            "default": null
-                        },
-                        "path": {
-                            "title": "ServiceMonitor endpoint path",
-                            "description": "ote that the /metrics endpoint is NOT present in a freshly scaffolded Backstage app. To setup, follow the Prometheus metrics tutorial. https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/prometheus-metrics.md",
-                            "type": "string",
-                            "default": "/metrics"
-                        }
-                    }
-                }
-            }
+            },
+            "title": "Service Account Configuration",
+            "type": "object"
         }
-    }
+    },
+    "title": "Backstage chart schema",
+    "type": "object"
 }

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -1,0 +1,772 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Backstage chart schema",
+    "properties": {
+        "global": {
+            "title": "Global parameters.",
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "title": "Global Docker image registry",
+                    "type": "string",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "title": "Global Docker registry secret names as an array",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true,
+                    "examples": [
+                        [
+                            "myRegistryKeySecretName"
+                        ]
+                    ]
+                }
+            }
+        },
+        "kubeVersion": {
+            "title": "Override Kubernetes version",
+            "type": "string",
+            "default": ""
+        },
+        "nameOverride": {
+            "title": "String to partially override common.names.fullname",
+            "type": "string",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "title": "String to fully override common.names.fullname",
+            "type": "string",
+            "default": ""
+        },
+        "clusterDomain": {
+            "title": "Default Kubernetes cluster domain",
+            "type": "string",
+            "default": "cluster.local"
+        },
+        "commonLabels": {
+            "title": "Labels to add to all deployed objects",
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            },
+            "default": {}
+        },
+        "commonAnnotations": {
+            "title": "Annotations to add to all deployed objects",
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            },
+            "default": {}
+        },
+        "extraDeploy": {
+            "title": "Array of extra objects to deploy with the release",
+            "type": "array",
+            "default": [],
+            "items": {
+                "type": [
+                    "string",
+                    "object"
+                ]
+            },
+            "uniqueItems": true
+        },
+        "diagnosticMode": {
+            "title": "Enable diagnostic mode in the Deployment",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "title": "Enable diagnostic mode",
+                    "description": "All probes will be disabled and the command will be overridden",
+                    "type": "boolean",
+                    "default": false
+                },
+                "command": {
+                    "title": "Command to override all containers in the Deployment",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "sleep"
+                    ]
+                },
+                "args": {
+                    "title": "Args to override all containers in the Deployment",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "infinity"
+                    ]
+                }
+            }
+        },
+        "ingress": {
+            "title": "Ingress parameters",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "title": "Enable the creation of the ingress resource",
+                    "type": "boolean",
+                    "default": false
+                },
+                "className": {
+                    "title": "Name of the IngressClass cluster resource which defines which controller will implement the resource.",
+                    "type": "string",
+                    "default": "",
+                    "examples": [
+                        "nginx"
+                    ]
+                },
+                "annotations": {
+                    "title": "Additional annotations for the Ingress resource",
+                    "type": "object",
+                    "default": {},
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "host": {
+                    "title": "Hostname to be used to expose the route to access the backstage application.",
+                    "type": "string",
+                    "default": "",
+                    "examples": [
+                        "backstage.10.0.0.1.nip.io"
+                    ]
+                },
+                "tls": {
+                    "title": "Ingress TLS parameters",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "title": "Enable TLS configuration",
+                            "description": "TLS for the host defined at `ingress.host` parameter",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "secretName": {
+                            "title": "The name to which the TLS Secret will be called",
+                            "type": "string",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "backstage": {
+            "title": "Backstage parameters",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "replicas": {
+                    "title": "Number of deployment replicas",
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 1
+                },
+                "revisionHistoryLimit": {
+                    "title": "The count of deployment revisions",
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 10
+                },
+                "image": {
+                    "title": "Image parameters",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "registry": {
+                            "title": "Backstage image registry",
+                            "type": "string",
+                            "default": "ghcr.io",
+                            "examples": [
+                                "ghcr.io",
+                                "quay.io",
+                                "docker.io"
+                            ]
+                        },
+                        "repository": {
+                            "title": "Backstage image repository",
+                            "type": "string",
+                            "default": "backstage/backstage"
+                        },
+                        "tag": {
+                            "title": "Backstage image tag",
+                            "description": "Immutable tags are recommended.",
+                            "type": "string",
+                            "default": "latest"
+                        },
+                        "pullPolicy": {
+                            "title": "Specify a imagePullPolicy.",
+                            "description": "Ref: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy",
+                            "type": "string",
+                            "default": "Always",
+                            "enum": [
+                                "Always",
+                                "IfNotPresent"
+                            ]
+                        },
+                        "pullSecrets": {
+                            "title": "Optionally specify an array of imagePullSecrets.",
+                            "description": "Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "default": [],
+                            "examples": [
+                                "myRegistryKeySecretName"
+                            ]
+                        },
+                        "debug": {
+                            "title": "Set to true if you would like to see extra information on logs",
+                            "type": "boolean",
+                            "default": false
+                        }
+                    }
+                },
+                "containerPorts": {
+                    "title": "Container ports on the Deployment",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "backend": {
+                            "title": "Backstage backend port.",
+                            "type": "integer",
+                            "default": 7007
+                        }
+                    }
+                },
+                "command": {
+                    "title": "Backstage container command",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "node",
+                        "packages/backend"
+                    ]
+                },
+                "args": {
+                    "title": "Backstage container command arguments",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "extraAppConfig": {
+                    "title": "Extra app configuration files to inline into command arguments",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "filename": {
+                                "type": "string"
+                            },
+                            "configMapRef": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "default": []
+                },
+                "extraContainers": {
+                    "title": "Deployment sidecars.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
+                    },
+                    "default": []
+                },
+                "extraEnvVars": {
+                    "title": "Backstage container environment variables",
+                    "type": "array",
+                    "items": {
+                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar"
+                    },
+                    "default": [],
+                    "examples": [
+                        [
+                            {
+                                "name": "APP_CONFIG_backend_cache_store",
+                                "value": "memory"
+                            }
+                        ]
+                    ]
+                },
+                "extraEnvVarsSecrets": {
+                    "title": "Backstage container environment variables from Secrets",
+                    "type": "array",
+                    "description": "Translates into array of `envFrom.[].secretRef.name`",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "examples": [
+                        [
+                            "my-backstage-secrets"
+                        ]
+                    ]
+                },
+                "extraVolumeMounts": {
+                    "title": "Backstage container additional volume mounts",
+                    "type": "array",
+                    "items": {
+                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount"
+                    },
+                    "default": []
+                },
+                "extraVolumes": {
+                    "title": "Backstage container additional volumes",
+                    "type": "array",
+                    "items": {
+                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
+                    },
+                    "default": []
+                },
+                "initContainers": {
+                    "title": "Backstage container init containers",
+                    "type": "array",
+                    "items": {
+                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
+                    },
+                    "default": []
+                },
+                "installDir": {
+                    "title": "Directory containing the backstage installation",
+                    "type": "string",
+                    "default": "/app"
+                },
+                "resources": {
+                    "title": "Resource requests/limits",
+                    "description": "Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container",
+                    "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+                    "default": {},
+                    "examples": [
+                        {
+                            "limits": {
+                                "memory": "1Gi",
+                                "cpu": "1000m"
+                            },
+                            "requests": {
+                                "memory": "250Mi",
+                                "cpu": "100m"
+                            }
+                        }
+                    ]
+                },
+                "readinessProbe": {
+                    "title": "Readiness probe",
+                    "description": "Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/",
+                    "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+                    "default": {},
+                    "examples": [
+                        {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/healthcheck",
+                                "port": 7007,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 30,
+                            "periodSeconds": 10,
+                            "successThreshold": 2,
+                            "timeoutSeconds": 2
+                        }
+                    ]
+                },
+                "livenessProbe": {
+                    "title": "Liveness probe",
+                    "description": "Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/",
+                    "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+                    "default": {},
+                    "examples": [
+                        {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/healthcheck",
+                                "port": 7007,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 60,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 2
+                        }
+                    ]
+                },
+                "startupProbe": {
+                    "title": "Startup probe",
+                    "description": "Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/",
+                    "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+                    "default": {},
+                    "examples": [
+                        {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/healthcheck",
+                                "port": 7007,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 60,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 2
+                        }
+                    ]
+                },
+                "podSecurityContext": {
+                    "title": "Security settings for a Pod.",
+                    "description": "The security settings that you specify for a Pod apply to all Containers in the Pod. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod",
+                    "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
+                    "default": {}
+                },
+                "containerSecurityContext": {
+                    "title": "Security settings for a Container.",
+                    "description": "Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container",
+                    "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
+                    "default": {}
+                },
+                "appConfig": {
+                    "title": "Generates ConfigMap and configures it in the Backstage pods",
+                    "type": [
+                        "object",
+                        "string"
+                    ],
+                    "default": {},
+                    "examples": [
+                        {
+                            "app": {
+                                "baseUrl": "https://somedomain.tld"
+                            }
+                        }
+                    ]
+                },
+                "nodeSelector": {
+                    "title": "Node labels for pod assignment",
+                    "description": "Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {}
+                },
+                "tolerations": {
+                    "title": "Node tolerations for server scheduling to nodes with taints",
+                    "description": "Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/",
+                    "type": "array",
+                    "items": {
+                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Toleration"
+                    },
+                    "default": []
+                },
+                "podAnnotations": {
+                    "title": "Annotations to add to the backend deployment pods",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {}
+                },
+                "podLabels": {
+                    "title": "Labels to add to the backend deployment pods",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {}
+                },
+                "annotations": {
+                    "title": "Additional custom annotations for the `Deployment` resource",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {}
+                }
+            }
+        },
+        "service": {
+            "title": "Service parameters",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "title": "Kubernetes Service type",
+                    "type": "string",
+                    "default": "ClusterIP",
+                    "enum": [
+                        "ClusterIP",
+                        "NodePort",
+                        "LoadBalancer",
+                        "ExternalName"
+                    ]
+                },
+                "ports": {
+                    "title": "Backstage svc port for client connections",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "backend": {
+                            "title": "Backstage svc port number",
+                            "type": "integer",
+                            "default": 7007
+                        },
+                        "name": {
+                            "title": "Backstage svc port name",
+                            "type": "string",
+                            "default": "http-backend"
+                        },
+                        "targetPort": {
+                            "title": "Backstage svc target port referencing receiving pod container port",
+                            "type": "string",
+                            "default": "backend"
+                        }
+                    }
+                },
+                "nodePorts": {
+                    "title": "Node port for the Backstage client connections",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "backend": {
+                            "title": "Node port for backend",
+                            "type": [
+                                "string",
+                                "integer"
+                            ],
+                            "default": "",
+                            "minimum": 30000,
+                            "maximum": 32767
+                        }
+                    }
+                },
+                "sessionAffinity": {
+                    "title": "Control where client requests go, to the same pod or round-robin",
+                    "description": "Ref: https://kubernetes.io/docs/concepts/services-networking/service/#session-stickiness",
+                    "type": "string",
+                    "default": "None",
+                    "enum": [
+                        "None",
+                        "ClientIP"
+                    ]
+                },
+                "clusterIP": {
+                    "title": "Backstage service Cluster IP",
+                    "type": "string",
+                    "default": ""
+                },
+                "loadBalancerIP": {
+                    "title": "Backstage service Load Balancer IP",
+                    "description": "Ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer",
+                    "type": "string",
+                    "default": ""
+                },
+                "loadBalancerSourceRanges": {
+                    "title": "Load Balancer sources",
+                    "description": "Ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "examples": [
+                        "10.10.10.0/24"
+                    ]
+                },
+                "externalTrafficPolicy": {
+                    "title": "Backstage service external traffic policy",
+                    "description": "Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip",
+                    "type": "string",
+                    "default": "Cluster",
+                    "enum": [
+                        "Cluster",
+                        "Local"
+                    ]
+                },
+                "annotations": {
+                    "title": "Additional custom annotations for Backstage service",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {}
+                },
+                "extraPorts": {
+                    "title": "Extra ports to expose in the Backstage service",
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    },
+                    "default": []
+                }
+            }
+        },
+        "networkPolicy": {
+            "title": "Network policies",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "title": "Specifies whether a NetworkPolicy should be created",
+                    "type": "boolean",
+                    "default": false
+                },
+                "ingressRules": {
+                    "title": "Custom egress rules for the network policy",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "customRules": {
+                            "title": "",
+                            "type": "array",
+                            "items": {
+                                "$ref": "https://kubernetesjsonschema.dev/v1.8.7/_definitions.json#/definitions/io.k8s.api.networking.v1.NetworkPolicyIngressRule"
+                            }
+                        },
+                        "namespaceSelector": {
+                            "title": "Namespace Selector.",
+                            "description": "Selects Namespaces using cluster scoped-labels.",
+                            "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "title": "Pod Selector.",
+                            "description": "Selects selects Pods in this namespace.",
+                            "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+                            "default": {}
+                        }
+                    }
+                },
+                "egressRules": {
+                    "title": "Custom egress rules for the network policy",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "customRules": {
+                            "title": "",
+                            "type": "array",
+                            "items": {
+                                "$ref": "https://kubernetesjsonschema.dev/v1.8.7/_definitions.json#/definitions/io.k8s.api.networking.v1.NetworkPolicyEgressRule"
+                            }
+                        },
+                        "denyConnectionsToExternal": {
+                            "title": "Deny external connections. Should not be enabled when working with an external database.",
+                            "type": "boolean",
+                            "default": false
+                        }
+                    }
+                }
+            }
+        },
+        "postgresql": {
+            "title": "PostgreSQL chart configuration",
+            "description": "Ref. https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml",
+            "$ref": "https://raw.githubusercontent.com/bitnami/charts/main/bitnami/postgresql/values.schema.json"
+        },
+        "serviceAccount": {
+            "title": "Service Account Configuration",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "create": {
+                    "title": "Enable the creation of a ServiceAccount for Backstage pods",
+                    "type": "boolean",
+                    "default": false
+                },
+                "name": {
+                    "title": "Name of the ServiceAccount to use",
+                    "description": "If not set and `serviceAccount.create` is true, a name is generated",
+                    "type": "string",
+                    "default": ""
+                },
+                "labels": {
+                    "title": "Additional custom labels to the service ServiceAccount.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {}
+                },
+                "annotations": {
+                    "title": "Additional custom annotations for the ServiceAccount.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {}
+                },
+                "automountServiceAccountToken": {
+                    "title": "Auto-mount the service account token in the pod",
+                    "type": "boolean",
+                    "default": true
+                }
+            }
+        },
+        "metrics": {
+            "title": "Metrics configuration",
+            "description": "Allows configuring your backstage instance as a scrape target for Prometheus. Ref: https://github.com/prometheus/prometheus",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "serviceMonitor": {
+                    "title": "ServiceMonitor configuration",
+                    "description": "A custom resource that is consumed by Prometheus Operator. Ref: https://github.com/prometheus-operator/prometheus-operator",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "title": "If enabled, a ServiceMonitor resource for Prometheus Operator is created",
+                            "description": "Prometheus Operator must be installed in your cluster prior to enabling.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "annotations": {
+                            "title": "ServiceMonitor annotations",
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "default": {}
+                        },
+                        "labels": {
+                            "title": "Additional ServiceMonitor labels",
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "default": {}
+                        },
+                        "interval": {
+                            "title": "ServiceMonitor scrape interval",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "default": null
+                        },
+                        "path": {
+                            "title": "ServiceMonitor endpoint path",
+                            "description": "ote that the /metrics endpoint is NOT present in a freshly scaffolded Backstage app. To setup, follow the Prometheus metrics tutorial. https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/prometheus-metrics.md",
+                            "type": "string",
+                            "default": "/metrics"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

Air-gapped environments should be supported. The only blocker we had here were remote references in `values.schema.json`. While these remote references reduce maintenance and repetition on our side, it requires helm to query for those references when processing values file.

Therefore to keep the benefits of remote references and allow consumers to install in air-gapped environment, I've added a small pre-commit script allowing us to treat the `values.schema.json` with remote references as a kind of template. I've moved our current `values.schema.json` to `values.schema.tmpl.json`. This template is dereferenced via pre-commit and the resulting schema with expanded references is stored as `values.schema.json`. This schema is then understood by Helm and can be used in air-gapped environments.

## Existing or Associated Issue(s)

Resolves https://github.com/backstage/charts/issues/127

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
