### PR TITLE
Added support for NetworkPolicies

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.0
+version: 1.5.1

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square)
+![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
@@ -174,10 +174,12 @@ Kubernetes: `>= 1.19.0-0`
 | metrics.serviceMonitor.labels | Additional ServiceMonitor labels | object | `{}` |
 | metrics.serviceMonitor.path | ServiceMonitor endpoint path <br /> Note that the /metrics endpoint is NOT present in a freshly scaffolded Backstage app. To setup, follow the [Prometheus metrics tutorial](https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/prometheus-metrics.md). | string | `"/metrics"` |
 | nameOverride | String to partially override common.names.fullname | string | `""` |
-| networkPolicy | Network policies <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/ | object | `{"egressRules":{"customRules":[]},"enabled":false,"externalAccess":{"from":[]}}` |
-| networkPolicy.egressRules | Custom network policy rule | object | `{"customRules":[]}` |
-| networkPolicy.egressRules.customRules | Additional custom egress rules e.g: customRules:   - to:       - namespaceSelector:           matchLabels:             label: example | list | `[]` |
-| networkPolicy.enabled | networkPolicy.enabled Specifies whether a NetworkPolicy should be created | bool | `false` |
+| networkPolicy.egressRules.customRules | Additional custom egress rules | list | `[]` |
+| networkPolicy.egressRules.denyConnectionsToExternal | Deny external connections. Should not be enabled when working with an external database. | bool | `false` |
+| networkPolicy.enabled | Specifies whether a NetworkPolicy should be created | bool | `false` |
+| networkPolicy.ingressRules.customRules | Additional custom ingress rules | list | `[]` |
+| networkPolicy.ingressRules.namespaceSelector | Namespace selector label allowed to access the Backstage instance | object | `{}` |
+| networkPolicy.ingressRules.podSelector | Pod selector label allowed to access the Backstage instance | object | `{}` |
 | postgresql | PostgreSQL [chart configuration](https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml) | object | See below |
 | postgresql.architecture | PostgreSQL architecture (`standalone` or `replication`) | string | `"standalone"` |
 | postgresql.auth | The authentication details of the Postgres database | object | `{"existingSecret":"","password":"","secretKeys":{"adminPasswordKey":"admin-password","replicationPasswordKey":"replication-password","userPasswordKey":"user-password"},"username":"bn_backstage"}` |

--- a/charts/backstage/templates/networkpolicy-egress.yaml
+++ b/charts/backstage/templates/networkpolicy-egress.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.networkPolicy.enabled (or .Values.networkPolicy.egressRules.denyConnectionsToExternal .Values.networkPolicy.egressRules.customRules) }}
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-egress" (include "common.names.fullname" .) }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{ include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: backstage
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.backstage.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.annotations "context" $) | nindent 4 }}
+    {{- end }}
+spec:
+  podSelector:
+    matchLabels:  {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: backstage
+  policyTypes:
+    - Egress
+  egress:
+    {{- if .Values.networkPolicy.egressRules.denyConnectionsToExternal }}
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - namespaceSelector: {}
+    {{- end }}
+    {{- if .Values.networkPolicy.egressRules.customRules }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.networkPolicy.egressRules.customRules "context" $) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/backstage/templates/networkpolicy.yaml
+++ b/charts/backstage/templates/networkpolicy.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.networkPolicy.enabled (or .Values.networkPolicy.ingressRules.namespaceSelector .Values.networkPolicy.ingressRules.podSelector .Values.networkPolicy.ingressRules.customRules) }}
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{ include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: backstage
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.backstage.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.annotations "context" $) | nindent 4 }}
+    {{- end }}
+spec:
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: backstage
+  ingress:
+    {{- if or .Values.networkPolicy.ingressRules.namespaceSelector .Values.networkPolicy.ingressRules.podSelector }}
+    - from:
+        {{- if .Values.networkPolicy.ingressRules.namespaceSelector }}
+        - namespaceSelector:
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.networkPolicy.ingressRules.namespaceSelector "context" $) | nindent 14 }}
+        {{- end }}
+        {{- if .Values.networkPolicy.ingressRules.podSelector }}
+        - podSelector:
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.networkPolicy.ingressRules.podSelector "context" $) | nindent 14 }}
+        {{- end }}
+      ports:
+        - port: {{ .Values.backstage.containerPorts.backend }}
+    {{- end }}
+    {{- if .Values.networkPolicy.ingressRules.customRules }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.networkPolicy.ingressRules.customRules "context" $) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -617,7 +617,6 @@
         },
         "networkPolicy": {
             "title": "Network policies",
-            "description": "Not used in any template. Ref. https://kubernetes.io/docs/concepts/services-networking/network-policies/",
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -626,9 +625,31 @@
                     "type": "boolean",
                     "default": false
                 },
-                "externalAccess": {
-                    "title": "Probably custom ingress rules for the network policy",
-                    "type": "object"
+                "ingressRules": {
+                    "title": "Custom egress rules for the network policy",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "customRules": {
+                            "title": "",
+                            "type": "array",
+                            "items": {
+                                "$ref": "https://kubernetesjsonschema.dev/v1.8.7/_definitions.json#/definitions/io.k8s.api.networking.v1.NetworkPolicyIngressRule"
+                            }
+                        },
+                        "namespaceSelector": {
+                            "title": "Namespace Selector.",
+                            "description": "Selects Namespaces using cluster scoped-labels.",
+                            "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+                            "default": {}
+                        },
+                        "podSelector": {
+                            "title": "Pod Selector.",
+                            "description": "Selects selects Pods in this namespace.",
+                            "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+                            "default": {}
+                        }
+                    }
                 },
                 "egressRules": {
                     "title": "Custom egress rules for the network policy",
@@ -641,6 +662,11 @@
                             "items": {
                                 "$ref": "https://kubernetesjsonschema.dev/v1.8.7/_definitions.json#/definitions/io.k8s.api.networking.v1.NetworkPolicyEgressRule"
                             }
+                        },
+                        "denyConnectionsToExternal": {
+                            "title": "Deny external connections. Should not be enabled when working with an external database.",
+                            "type": "boolean",
+                            "default": false
                         }
                     }
                 }

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -304,27 +304,42 @@ service:
   # -- Extra ports to expose in the Backstage service (normally used with the `sidecar` value)
   extraPorts: []
 
-# -- Network policies
-# <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+## @section NetworkPolicy parameters
+##
 networkPolicy:
-
-  # -- networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+  # -- Specifies whether a NetworkPolicy should be created
   enabled: false
 
-  externalAccess:
-    from: []
+  ## Ingress Rules
+  ##
+  ingressRules:
 
-  # -- Custom network policy rule
-  egressRules:
+    # -- Namespace selector label allowed to access the Backstage instance
+    namespaceSelector: {}
 
-    # -- Additional custom egress rules
-    # e.g:
-    # customRules:
+    # -- Pod selector label allowed to access the Backstage instance
+    podSelector: {}
+
+    # -- Additional custom ingress rules
+    customRules: []
     #   - to:
     #       - namespaceSelector:
     #           matchLabels:
     #             label: example
+
+  ## Egress Rules
+  ##
+  egressRules:
+
+    # -- Deny external connections. Should not be enabled when working with an external database.
+    denyConnectionsToExternal: false
+
+    # -- Additional custom egress rules
     customRules: []
+    #   - to:
+    #       - namespaceSelector:
+    #           matchLabels:
+    #             label: example
 
 
 # -- PostgreSQL [chart configuration](https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml)


### PR DESCRIPTION
## Description of the change

Added support for Ingress and Egress Network Policies

## Existing or Associated Issue(s)

#91 

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
