### PR TITLE
fix: Use an up-to-date `kubernetes` schema

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968 # pin@v1.5.0
+        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # pin@v1.6.0
         with:
           config: cr.yaml
         env:

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.0
+version: 1.6.1

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square)
+![Version: 1.6.1](https://img.shields.io/badge/Version-1.6.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -62,7 +62,7 @@
                     "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
                     "properties": {
                         "allowPrivilegeEscalation": {
-                            "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+                            "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
                             "type": "boolean"
                         },
                         "capabilities": {
@@ -86,19 +86,19 @@
                             "type": "object"
                         },
                         "privileged": {
-                            "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+                            "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
                             "type": "boolean"
                         },
                         "procMount": {
-                            "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+                            "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
                             "type": "string"
                         },
                         "readOnlyRootFilesystem": {
-                            "description": "Whether this container has a read-only root filesystem. Default is false.",
+                            "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
                             "type": "boolean"
                         },
                         "runAsGroup": {
-                            "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
                             "format": "int64",
                             "type": "integer"
                         },
@@ -107,7 +107,7 @@
                             "type": "boolean"
                         },
                         "runAsUser": {
-                            "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
                             "format": "int64",
                             "type": "integer"
                         },
@@ -133,6 +133,31 @@
                             },
                             "type": "object"
                         },
+                        "seccompProfile": {
+                            "description": "SeccompProfile defines a pod/container's seccomp profile settings. Only one profile source may be set.",
+                            "properties": {
+                                "localhostProfile": {
+                                    "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "description": "type indicates which kind of seccomp profile will be applied. Valid options are:\n\nLocalhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "type"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-unions": [
+                                {
+                                    "discriminator": "type",
+                                    "fields-to-discriminateBy": {
+                                        "localhostProfile": "LocalhostProfile"
+                                    }
+                                }
+                            ]
+                        },
                         "windowsOptions": {
                             "description": "WindowsSecurityContextOptions contain Windows-specific options and credentials.",
                             "properties": {
@@ -143,6 +168,10 @@
                                 "gmsaCredentialSpecName": {
                                     "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                                     "type": "string"
+                                },
+                                "hostProcess": {
+                                    "description": "HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                    "type": "boolean"
                                 },
                                 "runAsUserName": {
                                     "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
@@ -177,14 +206,14 @@
                         "description": "A single application container that you want to run within a pod.",
                         "properties": {
                             "args": {
-                                "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                "description": "Arguments to the entrypoint. The container image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
                                 "items": {
                                     "type": "string"
                                 },
                                 "type": "array"
                             },
                             "command": {
-                                "description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                "description": "Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
                                 "items": {
                                     "type": "string"
                                 },
@@ -200,7 +229,7 @@
                                             "type": "string"
                                         },
                                         "value": {
-                                            "description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                            "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
                                             "type": "string"
                                         },
                                         "valueFrom": {
@@ -225,7 +254,8 @@
                                                     "required": [
                                                         "key"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "fieldRef": {
                                                     "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
@@ -242,7 +272,8 @@
                                                     "required": [
                                                         "fieldPath"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "resourceFieldRef": {
                                                     "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
@@ -269,7 +300,8 @@
                                                     "required": [
                                                         "resource"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "secretKeyRef": {
                                                     "description": "SecretKeySelector selects a key of a Secret.",
@@ -290,7 +322,8 @@
                                                     "required": [
                                                         "key"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic"
                                                 }
                                             },
                                             "type": "object"
@@ -348,7 +381,7 @@
                                 "type": "array"
                             },
                             "image": {
-                                "description": "Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                                "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
                                 "type": "string"
                             },
                             "imagePullPolicy": {
@@ -359,7 +392,7 @@
                                 "description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
                                 "properties": {
                                     "postStart": {
-                                        "description": "Handler defines a specific action that should be taken",
+                                        "description": "LifecycleHandler defines a specific action that should be taken in a lifecycle hook. One and only one of the fields, except TCPSocket must be specified.",
                                         "properties": {
                                             "exec": {
                                                 "description": "ExecAction describes a \"run in container\" action.",
@@ -387,7 +420,7 @@
                                                             "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                                             "properties": {
                                                                 "name": {
-                                                                    "description": "The header field name",
+                                                                    "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                                                     "type": "string"
                                                                 },
                                                                 "value": {
@@ -424,6 +457,20 @@
                                                 },
                                                 "required": [
                                                     "port"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "sleep": {
+                                                "description": "SleepAction describes a \"sleep\" action.",
+                                                "properties": {
+                                                    "seconds": {
+                                                        "description": "Seconds is the number of seconds to sleep.",
+                                                        "format": "int64",
+                                                        "type": "integer"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "seconds"
                                                 ],
                                                 "type": "object"
                                             },
@@ -454,7 +501,7 @@
                                         "type": "object"
                                     },
                                     "preStop": {
-                                        "description": "Handler defines a specific action that should be taken",
+                                        "description": "LifecycleHandler defines a specific action that should be taken in a lifecycle hook. One and only one of the fields, except TCPSocket must be specified.",
                                         "properties": {
                                             "exec": {
                                                 "description": "ExecAction describes a \"run in container\" action.",
@@ -482,7 +529,7 @@
                                                             "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                                             "properties": {
                                                                 "name": {
-                                                                    "description": "The header field name",
+                                                                    "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                                                     "type": "string"
                                                                 },
                                                                 "value": {
@@ -519,6 +566,20 @@
                                                 },
                                                 "required": [
                                                     "port"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "sleep": {
+                                                "description": "SleepAction describes a \"sleep\" action.",
+                                                "properties": {
+                                                    "seconds": {
+                                                        "description": "Seconds is the number of seconds to sleep.",
+                                                        "format": "int64",
+                                                        "type": "integer"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "seconds"
                                                 ],
                                                 "type": "object"
                                             },
@@ -572,6 +633,23 @@
                                         "format": "int32",
                                         "type": "integer"
                                     },
+                                    "grpc": {
+                                        "properties": {
+                                            "port": {
+                                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                                "format": "int32",
+                                                "type": "integer"
+                                            },
+                                            "service": {
+                                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "port"
+                                        ],
+                                        "type": "object"
+                                    },
                                     "httpGet": {
                                         "description": "HTTPGetAction describes an action based on HTTP Get requests.",
                                         "properties": {
@@ -585,7 +663,7 @@
                                                     "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                                     "properties": {
                                                         "name": {
-                                                            "description": "The header field name",
+                                                            "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                                             "type": "string"
                                                         },
                                                         "value": {
@@ -663,6 +741,11 @@
                                         ],
                                         "type": "object"
                                     },
+                                    "terminationGracePeriodSeconds": {
+                                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                        "format": "int64",
+                                        "type": "integer"
+                                    },
                                     "timeoutSeconds": {
                                         "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                                         "format": "int32",
@@ -676,7 +759,7 @@
                                 "type": "string"
                             },
                             "ports": {
-                                "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+                                "description": "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.",
                                 "items": {
                                     "description": "ContainerPort represents a network port in a single container.",
                                     "properties": {
@@ -738,6 +821,23 @@
                                         "format": "int32",
                                         "type": "integer"
                                     },
+                                    "grpc": {
+                                        "properties": {
+                                            "port": {
+                                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                                "format": "int32",
+                                                "type": "integer"
+                                            },
+                                            "service": {
+                                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "port"
+                                        ],
+                                        "type": "object"
+                                    },
                                     "httpGet": {
                                         "description": "HTTPGetAction describes an action based on HTTP Get requests.",
                                         "properties": {
@@ -751,7 +851,7 @@
                                                     "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                                     "properties": {
                                                         "name": {
-                                                            "description": "The header field name",
+                                                            "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                                             "type": "string"
                                                         },
                                                         "value": {
@@ -829,6 +929,11 @@
                                         ],
                                         "type": "object"
                                     },
+                                    "terminationGracePeriodSeconds": {
+                                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                        "format": "int64",
+                                        "type": "integer"
+                                    },
                                     "timeoutSeconds": {
                                         "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                                         "format": "int32",
@@ -837,9 +942,53 @@
                                 },
                                 "type": "object"
                             },
+                            "resizePolicy": {
+                                "description": "Resources resize policy for the container.",
+                                "items": {
+                                    "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                                    "properties": {
+                                        "resourceName": {
+                                            "description": "Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.",
+                                            "type": "string"
+                                        },
+                                        "restartPolicy": {
+                                            "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "resourceName",
+                                        "restartPolicy"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                            },
                             "resources": {
                                 "description": "ResourceRequirements describes the compute resource requirements.",
                                 "properties": {
+                                    "claims": {
+                                        "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.\n\nThis is an alpha field and requires enabling the DynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                                        "items": {
+                                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                            "properties": {
+                                                "name": {
+                                                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "name"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-map-keys": [
+                                            "name"
+                                        ],
+                                        "x-kubernetes-list-type": "map"
+                                    },
                                     "limits": {
                                         "additionalProperties": {
                                             "oneOf": [
@@ -851,7 +1000,7 @@
                                                 }
                                             ]
                                         },
-                                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                                         "type": "object"
                                     },
                                     "requests": {
@@ -865,17 +1014,21 @@
                                                 }
                                             ]
                                         },
-                                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                                         "type": "object"
                                     }
                                 },
                                 "type": "object"
                             },
+                            "restartPolicy": {
+                                "description": "RestartPolicy defines the restart behavior of individual containers in a pod. This field may only be set for init containers, and the only allowed value is \"Always\". For non-init containers or when this field is not specified, the restart behavior is defined by the Pod's restart policy and the container type. Setting the RestartPolicy as \"Always\" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy \"Always\" will be shut down. This lifecycle differs from normal init containers and is often referred to as a \"sidecar\" container. Although this init container still starts in the init container sequence, it does not wait for the container to complete before proceeding to the next init container. Instead, the next init container starts immediately after this init container is started, or after any startupProbe has successfully completed.",
+                                "type": "string"
+                            },
                             "securityContext": {
                                 "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
                                 "properties": {
                                     "allowPrivilegeEscalation": {
-                                        "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+                                        "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
                                         "type": "boolean"
                                     },
                                     "capabilities": {
@@ -899,19 +1052,19 @@
                                         "type": "object"
                                     },
                                     "privileged": {
-                                        "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+                                        "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
                                         "type": "boolean"
                                     },
                                     "procMount": {
-                                        "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+                                        "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
                                         "type": "string"
                                     },
                                     "readOnlyRootFilesystem": {
-                                        "description": "Whether this container has a read-only root filesystem. Default is false.",
+                                        "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
                                         "type": "boolean"
                                     },
                                     "runAsGroup": {
-                                        "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                        "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
                                         "format": "int64",
                                         "type": "integer"
                                     },
@@ -920,7 +1073,7 @@
                                         "type": "boolean"
                                     },
                                     "runAsUser": {
-                                        "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                        "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
                                         "format": "int64",
                                         "type": "integer"
                                     },
@@ -946,6 +1099,31 @@
                                         },
                                         "type": "object"
                                     },
+                                    "seccompProfile": {
+                                        "description": "SeccompProfile defines a pod/container's seccomp profile settings. Only one profile source may be set.",
+                                        "properties": {
+                                            "localhostProfile": {
+                                                "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "description": "type indicates which kind of seccomp profile will be applied. Valid options are:\n\nLocalhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "type"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-unions": [
+                                            {
+                                                "discriminator": "type",
+                                                "fields-to-discriminateBy": {
+                                                    "localhostProfile": "LocalhostProfile"
+                                                }
+                                            }
+                                        ]
+                                    },
                                     "windowsOptions": {
                                         "description": "WindowsSecurityContextOptions contain Windows-specific options and credentials.",
                                         "properties": {
@@ -956,6 +1134,10 @@
                                             "gmsaCredentialSpecName": {
                                                 "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                                                 "type": "string"
+                                            },
+                                            "hostProcess": {
+                                                "description": "HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                                "type": "boolean"
                                             },
                                             "runAsUserName": {
                                                 "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
@@ -988,6 +1170,23 @@
                                         "format": "int32",
                                         "type": "integer"
                                     },
+                                    "grpc": {
+                                        "properties": {
+                                            "port": {
+                                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                                "format": "int32",
+                                                "type": "integer"
+                                            },
+                                            "service": {
+                                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "port"
+                                        ],
+                                        "type": "object"
+                                    },
                                     "httpGet": {
                                         "description": "HTTPGetAction describes an action based on HTTP Get requests.",
                                         "properties": {
@@ -1001,7 +1200,7 @@
                                                     "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                                     "properties": {
                                                         "name": {
-                                                            "description": "The header field name",
+                                                            "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                                             "type": "string"
                                                         },
                                                         "value": {
@@ -1078,6 +1277,11 @@
                                             "port"
                                         ],
                                         "type": "object"
+                                    },
+                                    "terminationGracePeriodSeconds": {
+                                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                        "format": "int64",
+                                        "type": "integer"
                                     },
                                     "timeoutSeconds": {
                                         "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
@@ -1202,7 +1406,7 @@
                                 "type": "string"
                             },
                             "value": {
-                                "description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
                                 "type": "string"
                             },
                             "valueFrom": {
@@ -1227,7 +1431,8 @@
                                         "required": [
                                             "key"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
                                     },
                                     "fieldRef": {
                                         "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
@@ -1244,7 +1449,8 @@
                                         "required": [
                                             "fieldPath"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
                                     },
                                     "resourceFieldRef": {
                                         "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
@@ -1271,7 +1477,8 @@
                                         "required": [
                                             "resource"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
                                     },
                                     "secretKeyRef": {
                                         "description": "SecretKeySelector selects a key of a Secret.",
@@ -1292,7 +1499,8 @@
                                         "required": [
                                             "key"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
                                     }
                                 },
                                 "type": "object"
@@ -1368,20 +1576,20 @@
                                 "description": "Represents a Persistent Disk resource in AWS.\n\nAn AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.",
                                 "properties": {
                                     "fsType": {
-                                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                        "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                                         "type": "string"
                                     },
                                     "partition": {
-                                        "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                                        "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
                                         "format": "int32",
                                         "type": "integer"
                                     },
                                     "readOnly": {
-                                        "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                        "description": "readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                                         "type": "boolean"
                                     },
                                     "volumeID": {
-                                        "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                        "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                                         "type": "string"
                                     }
                                 },
@@ -1394,27 +1602,27 @@
                                 "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
                                 "properties": {
                                     "cachingMode": {
-                                        "description": "Host Caching mode: None, Read Only, Read Write.",
+                                        "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
                                         "type": "string"
                                     },
                                     "diskName": {
-                                        "description": "The Name of the data disk in the blob storage",
+                                        "description": "diskName is the Name of the data disk in the blob storage",
                                         "type": "string"
                                     },
                                     "diskURI": {
-                                        "description": "The URI the data disk in the blob storage",
+                                        "description": "diskURI is the URI of data disk in the blob storage",
                                         "type": "string"
                                     },
                                     "fsType": {
-                                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                        "description": "fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                                         "type": "string"
                                     },
                                     "kind": {
-                                        "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                                        "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
                                         "type": "string"
                                     },
                                     "readOnly": {
-                                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                        "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                                         "type": "boolean"
                                     }
                                 },
@@ -1428,15 +1636,15 @@
                                 "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
                                 "properties": {
                                     "readOnly": {
-                                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                        "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                                         "type": "boolean"
                                     },
                                     "secretName": {
-                                        "description": "the name of secret that contains Azure Storage Account Name and Key",
+                                        "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
                                         "type": "string"
                                     },
                                     "shareName": {
-                                        "description": "Share Name",
+                                        "description": "shareName is the azure share Name",
                                         "type": "string"
                                     }
                                 },
@@ -1450,22 +1658,22 @@
                                 "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
                                 "properties": {
                                     "monitors": {
-                                        "description": "Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                        "description": "monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                                         "items": {
                                             "type": "string"
                                         },
                                         "type": "array"
                                     },
                                     "path": {
-                                        "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                                        "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
                                         "type": "string"
                                     },
                                     "readOnly": {
-                                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                        "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                                         "type": "boolean"
                                     },
                                     "secretFile": {
-                                        "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                        "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                                         "type": "string"
                                     },
                                     "secretRef": {
@@ -1476,10 +1684,11 @@
                                                 "type": "string"
                                             }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
                                     },
                                     "user": {
-                                        "description": "Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                        "description": "user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                                         "type": "string"
                                     }
                                 },
@@ -1492,11 +1701,11 @@
                                 "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
                                 "properties": {
                                     "fsType": {
-                                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                        "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                                         "type": "string"
                                     },
                                     "readOnly": {
-                                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                        "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                                         "type": "boolean"
                                     },
                                     "secretRef": {
@@ -1507,10 +1716,11 @@
                                                 "type": "string"
                                             }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
                                     },
                                     "volumeID": {
-                                        "description": "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                        "description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                                         "type": "string"
                                     }
                                 },
@@ -1523,26 +1733,26 @@
                                 "description": "Adapts a ConfigMap into a volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.",
                                 "properties": {
                                     "defaultMode": {
-                                        "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "description": "defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                         "format": "int32",
                                         "type": "integer"
                                     },
                                     "items": {
-                                        "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                        "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
                                         "items": {
                                             "description": "Maps a string key to a path within a volume.",
                                             "properties": {
                                                 "key": {
-                                                    "description": "The key to project.",
+                                                    "description": "key is the key to project.",
                                                     "type": "string"
                                                 },
                                                 "mode": {
-                                                    "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                    "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                                     "format": "int32",
                                                     "type": "integer"
                                                 },
                                                 "path": {
-                                                    "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                    "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                                     "type": "string"
                                                 }
                                             },
@@ -1559,7 +1769,7 @@
                                         "type": "string"
                                     },
                                     "optional": {
-                                        "description": "Specify whether the ConfigMap or its keys must be defined",
+                                        "description": "optional specify whether the ConfigMap or its keys must be defined",
                                         "type": "boolean"
                                     }
                                 },
@@ -1569,11 +1779,11 @@
                                 "description": "Represents a source location of a volume to mount, managed by an external CSI driver",
                                 "properties": {
                                     "driver": {
-                                        "description": "Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                                        "description": "driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
                                         "type": "string"
                                     },
                                     "fsType": {
-                                        "description": "Filesystem type to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                                        "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
                                         "type": "string"
                                     },
                                     "nodePublishSecretRef": {
@@ -1584,17 +1794,18 @@
                                                 "type": "string"
                                             }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
                                     },
                                     "readOnly": {
-                                        "description": "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                                        "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
                                         "type": "boolean"
                                     },
                                     "volumeAttributes": {
                                         "additionalProperties": {
                                             "type": "string"
                                         },
-                                        "description": "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                                        "description": "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
                                         "type": "object"
                                     }
                                 },
@@ -1631,7 +1842,8 @@
                                                     "required": [
                                                         "fieldPath"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "mode": {
                                                     "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
@@ -1667,7 +1879,8 @@
                                                     "required": [
                                                         "resource"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic"
                                                 }
                                             },
                                             "required": [
@@ -1684,7 +1897,7 @@
                                 "description": "Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.",
                                 "properties": {
                                     "medium": {
-                                        "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                                        "description": "medium represents what type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                                         "type": "string"
                                     },
                                     "sizeLimit": {
@@ -1700,31 +1913,354 @@
                                 },
                                 "type": "object"
                             },
+                            "ephemeral": {
+                                "description": "Represents an ephemeral volume that is handled by a normal storage driver.",
+                                "properties": {
+                                    "volumeClaimTemplate": {
+                                        "description": "PersistentVolumeClaimTemplate is used to produce PersistentVolumeClaim objects as part of an EphemeralVolumeSource.",
+                                        "properties": {
+                                            "metadata": {
+                                                "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+                                                "properties": {
+                                                    "annotations": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                                                        "type": "object"
+                                                    },
+                                                    "creationTimestamp": {
+                                                        "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                                                        "format": "date-time",
+                                                        "type": "string"
+                                                    },
+                                                    "deletionGracePeriodSeconds": {
+                                                        "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+                                                        "format": "int64",
+                                                        "type": "integer"
+                                                    },
+                                                    "deletionTimestamp": {
+                                                        "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                                                        "format": "date-time",
+                                                        "type": "string"
+                                                    },
+                                                    "finalizers": {
+                                                        "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-patch-strategy": "merge"
+                                                    },
+                                                    "generateName": {
+                                                        "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                                                        "type": "string"
+                                                    },
+                                                    "generation": {
+                                                        "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+                                                        "format": "int64",
+                                                        "type": "integer"
+                                                    },
+                                                    "labels": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                                                        "type": "object"
+                                                    },
+                                                    "managedFields": {
+                                                        "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+                                                        "items": {
+                                                            "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+                                                            "properties": {
+                                                                "apiVersion": {
+                                                                    "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+                                                                    "type": "string"
+                                                                },
+                                                                "fieldsType": {
+                                                                    "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+                                                                    "type": "string"
+                                                                },
+                                                                "fieldsV1": {
+                                                                    "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+                                                                    "type": "object"
+                                                                },
+                                                                "manager": {
+                                                                    "description": "Manager is an identifier of the workflow managing these fields.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operation": {
+                                                                    "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+                                                                    "type": "string"
+                                                                },
+                                                                "subresource": {
+                                                                    "description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+                                                                    "type": "string"
+                                                                },
+                                                                "time": {
+                                                                    "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                                                                    "format": "date-time",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "name": {
+                                                        "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+                                                        "type": "string"
+                                                    },
+                                                    "namespace": {
+                                                        "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces",
+                                                        "type": "string"
+                                                    },
+                                                    "ownerReferences": {
+                                                        "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+                                                        "items": {
+                                                            "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+                                                            "properties": {
+                                                                "apiVersion": {
+                                                                    "description": "API version of the referent.",
+                                                                    "type": "string"
+                                                                },
+                                                                "blockOwnerDeletion": {
+                                                                    "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                                                                    "type": "boolean"
+                                                                },
+                                                                "controller": {
+                                                                    "description": "If true, this reference points to the managing controller.",
+                                                                    "type": "boolean"
+                                                                },
+                                                                "kind": {
+                                                                    "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                                    "type": "string"
+                                                                },
+                                                                "name": {
+                                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+                                                                    "type": "string"
+                                                                },
+                                                                "uid": {
+                                                                    "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "apiVersion",
+                                                                "kind",
+                                                                "name",
+                                                                "uid"
+                                                            ],
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-patch-merge-key": "uid",
+                                                        "x-kubernetes-patch-strategy": "merge"
+                                                    },
+                                                    "resourceVersion": {
+                                                        "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                                        "type": "string"
+                                                    },
+                                                    "selfLink": {
+                                                        "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+                                                        "type": "string"
+                                                    },
+                                                    "uid": {
+                                                        "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            "spec": {
+                                                "description": "PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes",
+                                                "properties": {
+                                                    "accessModes": {
+                                                        "description": "accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "dataSource": {
+                                                        "description": "TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.",
+                                                        "properties": {
+                                                            "apiGroup": {
+                                                                "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                                                "type": "string"
+                                                            },
+                                                            "kind": {
+                                                                "description": "Kind is the type of resource being referenced",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name is the name of resource being referenced",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "kind",
+                                                            "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic"
+                                                    },
+                                                    "dataSourceRef": {
+                                                        "properties": {
+                                                            "apiGroup": {
+                                                                "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                                                "type": "string"
+                                                            },
+                                                            "kind": {
+                                                                "description": "Kind is the type of resource being referenced",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name is the name of resource being referenced",
+                                                                "type": "string"
+                                                            },
+                                                            "namespace": {
+                                                                "description": "Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "kind",
+                                                            "name"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    "resources": {
+                                                        "description": "VolumeResourceRequirements describes the storage resource requirements for a volume.",
+                                                        "properties": {
+                                                            "limits": {
+                                                                "additionalProperties": {
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                                                "type": "object"
+                                                            },
+                                                            "requests": {
+                                                                "additionalProperties": {
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    "selector": {
+                                                        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                                        "properties": {
+                                                            "matchExpressions": {
+                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the label key that the selector applies to.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "matchLabels": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic"
+                                                    },
+                                                    "storageClassName": {
+                                                        "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                                        "type": "string"
+                                                    },
+                                                    "volumeAttributesClassName": {
+                                                        "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim. If specified, the CSI driver will create or update the volume with the attributes defined in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName, it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass will be applied to the claim but it's not allowed to reset this field to empty string once it is set. If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass will be set by the persistentvolume controller if it exists. If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.",
+                                                        "type": "string"
+                                                    },
+                                                    "volumeMode": {
+                                                        "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
+                                                        "type": "string"
+                                                    },
+                                                    "volumeName": {
+                                                        "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            }
+                                        },
+                                        "required": [
+                                            "spec"
+                                        ],
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            },
                             "fc": {
                                 "description": "Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.",
                                 "properties": {
                                     "fsType": {
-                                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                        "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                                         "type": "string"
                                     },
                                     "lun": {
-                                        "description": "Optional: FC target lun number",
+                                        "description": "lun is Optional: FC target lun number",
                                         "format": "int32",
                                         "type": "integer"
                                     },
                                     "readOnly": {
-                                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                        "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                                         "type": "boolean"
                                     },
                                     "targetWWNs": {
-                                        "description": "Optional: FC target worldwide names (WWNs)",
+                                        "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
                                         "items": {
                                             "type": "string"
                                         },
                                         "type": "array"
                                     },
                                     "wwids": {
-                                        "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                                        "description": "wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
                                         "items": {
                                             "type": "string"
                                         },
@@ -1737,22 +2273,22 @@
                                 "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
                                 "properties": {
                                     "driver": {
-                                        "description": "Driver is the name of the driver to use for this volume.",
+                                        "description": "driver is the name of the driver to use for this volume.",
                                         "type": "string"
                                     },
                                     "fsType": {
-                                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                                        "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
                                         "type": "string"
                                     },
                                     "options": {
                                         "additionalProperties": {
                                             "type": "string"
                                         },
-                                        "description": "Optional: Extra command options if any.",
+                                        "description": "options is Optional: this field holds extra command options if any.",
                                         "type": "object"
                                     },
                                     "readOnly": {
-                                        "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                        "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                                         "type": "boolean"
                                     },
                                     "secretRef": {
@@ -1763,7 +2299,8 @@
                                                 "type": "string"
                                             }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
                                     }
                                 },
                                 "required": [
@@ -1775,11 +2312,11 @@
                                 "description": "Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.",
                                 "properties": {
                                     "datasetName": {
-                                        "description": "Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+                                        "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
                                         "type": "string"
                                     },
                                     "datasetUUID": {
-                                        "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+                                        "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
                                         "type": "string"
                                     }
                                 },
@@ -1789,20 +2326,20 @@
                                 "description": "Represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.",
                                 "properties": {
                                     "fsType": {
-                                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                        "description": "fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                                         "type": "string"
                                     },
                                     "partition": {
-                                        "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                        "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                                         "format": "int32",
                                         "type": "integer"
                                     },
                                     "pdName": {
-                                        "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                        "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                                         "type": "string"
                                     },
                                     "readOnly": {
-                                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                        "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                                         "type": "boolean"
                                     }
                                 },
@@ -1815,15 +2352,15 @@
                                 "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
                                 "properties": {
                                     "directory": {
-                                        "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+                                        "description": "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
                                         "type": "string"
                                     },
                                     "repository": {
-                                        "description": "Repository URL",
+                                        "description": "repository is the URL",
                                         "type": "string"
                                     },
                                     "revision": {
-                                        "description": "Commit hash for the specified revision.",
+                                        "description": "revision is the commit hash for the specified revision.",
                                         "type": "string"
                                     }
                                 },
@@ -1836,15 +2373,15 @@
                                 "description": "Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.",
                                 "properties": {
                                     "endpoints": {
-                                        "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                        "description": "endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                                         "type": "string"
                                     },
                                     "path": {
-                                        "description": "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                        "description": "path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                                         "type": "string"
                                     },
                                     "readOnly": {
-                                        "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                        "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                                         "type": "boolean"
                                     }
                                 },
@@ -1858,11 +2395,11 @@
                                 "description": "Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.",
                                 "properties": {
                                     "path": {
-                                        "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                        "description": "path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                                         "type": "string"
                                     },
                                     "type": {
-                                        "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                        "description": "type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                                         "type": "string"
                                     }
                                 },
@@ -1875,43 +2412,43 @@
                                 "description": "Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
                                 "properties": {
                                     "chapAuthDiscovery": {
-                                        "description": "whether support iSCSI Discovery CHAP authentication",
+                                        "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
                                         "type": "boolean"
                                     },
                                     "chapAuthSession": {
-                                        "description": "whether support iSCSI Session CHAP authentication",
+                                        "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
                                         "type": "boolean"
                                     },
                                     "fsType": {
-                                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+                                        "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
                                         "type": "string"
                                     },
                                     "initiatorName": {
-                                        "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+                                        "description": "initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
                                         "type": "string"
                                     },
                                     "iqn": {
-                                        "description": "Target iSCSI Qualified Name.",
+                                        "description": "iqn is the target iSCSI Qualified Name.",
                                         "type": "string"
                                     },
                                     "iscsiInterface": {
-                                        "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+                                        "description": "iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
                                         "type": "string"
                                     },
                                     "lun": {
-                                        "description": "iSCSI Target Lun number.",
+                                        "description": "lun represents iSCSI Target Lun number.",
                                         "format": "int32",
                                         "type": "integer"
                                     },
                                     "portals": {
-                                        "description": "iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                                        "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
                                         "items": {
                                             "type": "string"
                                         },
                                         "type": "array"
                                     },
                                     "readOnly": {
-                                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+                                        "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
                                         "type": "boolean"
                                     },
                                     "secretRef": {
@@ -1922,10 +2459,11 @@
                                                 "type": "string"
                                             }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
                                     },
                                     "targetPortal": {
-                                        "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                                        "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
                                         "type": "string"
                                     }
                                 },
@@ -1937,22 +2475,22 @@
                                 "type": "object"
                             },
                             "name": {
-                                "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "description": "name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                 "type": "string"
                             },
                             "nfs": {
                                 "description": "Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.",
                                 "properties": {
                                     "path": {
-                                        "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                        "description": "path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                                         "type": "string"
                                     },
                                     "readOnly": {
-                                        "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                        "description": "readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                                         "type": "boolean"
                                     },
                                     "server": {
-                                        "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                        "description": "server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                                         "type": "string"
                                     }
                                 },
@@ -1966,11 +2504,11 @@
                                 "description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).",
                                 "properties": {
                                     "claimName": {
-                                        "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                                        "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                                         "type": "string"
                                     },
                                     "readOnly": {
-                                        "description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
+                                        "description": "readOnly Will force the ReadOnly setting in VolumeMounts. Default false.",
                                         "type": "boolean"
                                     }
                                 },
@@ -1983,11 +2521,11 @@
                                 "description": "Represents a Photon Controller persistent disk resource.",
                                 "properties": {
                                     "fsType": {
-                                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                        "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                                         "type": "string"
                                     },
                                     "pdID": {
-                                        "description": "ID that identifies Photon Controller persistent disk",
+                                        "description": "pdID is the ID that identifies Photon Controller persistent disk",
                                         "type": "string"
                                     }
                                 },
@@ -2000,15 +2538,15 @@
                                 "description": "PortworxVolumeSource represents a Portworx volume resource.",
                                 "properties": {
                                     "fsType": {
-                                        "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                        "description": "fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                                         "type": "string"
                                     },
                                     "readOnly": {
-                                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                        "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                                         "type": "boolean"
                                     },
                                     "volumeID": {
-                                        "description": "VolumeID uniquely identifies a Portworx volume",
+                                        "description": "volumeID uniquely identifies a Portworx volume",
                                         "type": "string"
                                     }
                                 },
@@ -2021,34 +2559,102 @@
                                 "description": "Represents a projected volume source",
                                 "properties": {
                                     "defaultMode": {
-                                        "description": "Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "description": "defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                         "format": "int32",
                                         "type": "integer"
                                     },
                                     "sources": {
-                                        "description": "list of volume projections",
+                                        "description": "sources is the list of volume projections",
                                         "items": {
                                             "description": "Projection that may be projected along with other supported volume types",
                                             "properties": {
+                                                "clusterTrustBundle": {
+                                                    "description": "ClusterTrustBundleProjection describes how to select a set of ClusterTrustBundle objects and project their contents into the pod filesystem.",
+                                                    "properties": {
+                                                        "labelSelector": {
+                                                            "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                                            "properties": {
+                                                                "matchExpressions": {
+                                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                    "items": {
+                                                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                        "properties": {
+                                                                            "key": {
+                                                                                "description": "key is the label key that the selector applies to.",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                                "items": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "type": "array"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "key",
+                                                                            "operator"
+                                                                        ],
+                                                                        "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                },
+                                                                "matchLabels": {
+                                                                    "additionalProperties": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                    "type": "object"
+                                                                }
+                                                            },
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic"
+                                                        },
+                                                        "name": {
+                                                            "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive with signerName and labelSelector.",
+                                                            "type": "string"
+                                                        },
+                                                        "optional": {
+                                                            "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s) aren't available.  If using name, then the named ClusterTrustBundle is allowed not to exist.  If using signerName, then the combination of signerName and labelSelector is allowed to match zero ClusterTrustBundles.",
+                                                            "type": "boolean"
+                                                        },
+                                                        "path": {
+                                                            "description": "Relative path from the volume root to write the bundle.",
+                                                            "type": "string"
+                                                        },
+                                                        "signerName": {
+                                                            "description": "Select all ClusterTrustBundles that match this signer name. Mutually-exclusive with name.  The contents of all selected ClusterTrustBundles will be unified and deduplicated.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "path"
+                                                    ],
+                                                    "type": "object"
+                                                },
                                                 "configMap": {
                                                     "description": "Adapts a ConfigMap into a projected volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.",
                                                     "properties": {
                                                         "items": {
-                                                            "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                                            "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
                                                             "items": {
                                                                 "description": "Maps a string key to a path within a volume.",
                                                                 "properties": {
                                                                     "key": {
-                                                                        "description": "The key to project.",
+                                                                        "description": "key is the key to project.",
                                                                         "type": "string"
                                                                     },
                                                                     "mode": {
-                                                                        "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                        "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                                                         "format": "int32",
                                                                         "type": "integer"
                                                                     },
                                                                     "path": {
-                                                                        "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                                        "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                                                         "type": "string"
                                                                     }
                                                                 },
@@ -2065,7 +2671,7 @@
                                                             "type": "string"
                                                         },
                                                         "optional": {
-                                                            "description": "Specify whether the ConfigMap or its keys must be defined",
+                                                            "description": "optional specify whether the ConfigMap or its keys must be defined",
                                                             "type": "boolean"
                                                         }
                                                     },
@@ -2094,7 +2700,8 @@
                                                                         "required": [
                                                                             "fieldPath"
                                                                         ],
-                                                                        "type": "object"
+                                                                        "type": "object",
+                                                                        "x-kubernetes-map-type": "atomic"
                                                                     },
                                                                     "mode": {
                                                                         "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
@@ -2130,7 +2737,8 @@
                                                                         "required": [
                                                                             "resource"
                                                                         ],
-                                                                        "type": "object"
+                                                                        "type": "object",
+                                                                        "x-kubernetes-map-type": "atomic"
                                                                     }
                                                                 },
                                                                 "required": [
@@ -2147,21 +2755,21 @@
                                                     "description": "Adapts a secret into a projected volume.\n\nThe contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.",
                                                     "properties": {
                                                         "items": {
-                                                            "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                                            "description": "items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
                                                             "items": {
                                                                 "description": "Maps a string key to a path within a volume.",
                                                                 "properties": {
                                                                     "key": {
-                                                                        "description": "The key to project.",
+                                                                        "description": "key is the key to project.",
                                                                         "type": "string"
                                                                     },
                                                                     "mode": {
-                                                                        "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                        "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                                                         "format": "int32",
                                                                         "type": "integer"
                                                                     },
                                                                     "path": {
-                                                                        "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                                        "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                                                         "type": "string"
                                                                     }
                                                                 },
@@ -2178,7 +2786,7 @@
                                                             "type": "string"
                                                         },
                                                         "optional": {
-                                                            "description": "Specify whether the Secret or its key must be defined",
+                                                            "description": "optional field specify whether the Secret or its key must be defined",
                                                             "type": "boolean"
                                                         }
                                                     },
@@ -2188,16 +2796,16 @@
                                                     "description": "ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).",
                                                     "properties": {
                                                         "audience": {
-                                                            "description": "Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+                                                            "description": "audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
                                                             "type": "string"
                                                         },
                                                         "expirationSeconds": {
-                                                            "description": "ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+                                                            "description": "expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
                                                             "format": "int64",
                                                             "type": "integer"
                                                         },
                                                         "path": {
-                                                            "description": "Path is the path relative to the mount point of the file to project the token into.",
+                                                            "description": "path is the path relative to the mount point of the file to project the token into.",
                                                             "type": "string"
                                                         }
                                                     },
@@ -2212,36 +2820,33 @@
                                         "type": "array"
                                     }
                                 },
-                                "required": [
-                                    "sources"
-                                ],
                                 "type": "object"
                             },
                             "quobyte": {
                                 "description": "Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.",
                                 "properties": {
                                     "group": {
-                                        "description": "Group to map volume access to Default is no group",
+                                        "description": "group to map volume access to Default is no group",
                                         "type": "string"
                                     },
                                     "readOnly": {
-                                        "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+                                        "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
                                         "type": "boolean"
                                     },
                                     "registry": {
-                                        "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+                                        "description": "registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
                                         "type": "string"
                                     },
                                     "tenant": {
-                                        "description": "Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                                        "description": "tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
                                         "type": "string"
                                     },
                                     "user": {
-                                        "description": "User to map volume access to Defaults to serivceaccount user",
+                                        "description": "user to map volume access to Defaults to serivceaccount user",
                                         "type": "string"
                                     },
                                     "volume": {
-                                        "description": "Volume is a string that references an already created Quobyte volume by name.",
+                                        "description": "volume is a string that references an already created Quobyte volume by name.",
                                         "type": "string"
                                     }
                                 },
@@ -2255,30 +2860,30 @@
                                 "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
                                 "properties": {
                                     "fsType": {
-                                        "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+                                        "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
                                         "type": "string"
                                     },
                                     "image": {
-                                        "description": "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                        "description": "image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                                         "type": "string"
                                     },
                                     "keyring": {
-                                        "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                        "description": "keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                                         "type": "string"
                                     },
                                     "monitors": {
-                                        "description": "A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                        "description": "monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                                         "items": {
                                             "type": "string"
                                         },
                                         "type": "array"
                                     },
                                     "pool": {
-                                        "description": "The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                        "description": "pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                                         "type": "string"
                                     },
                                     "readOnly": {
-                                        "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                        "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                                         "type": "boolean"
                                     },
                                     "secretRef": {
@@ -2289,10 +2894,11 @@
                                                 "type": "string"
                                             }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
                                     },
                                     "user": {
-                                        "description": "The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                        "description": "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                                         "type": "string"
                                     }
                                 },
@@ -2306,19 +2912,19 @@
                                 "description": "ScaleIOVolumeSource represents a persistent ScaleIO volume",
                                 "properties": {
                                     "fsType": {
-                                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+                                        "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
                                         "type": "string"
                                     },
                                     "gateway": {
-                                        "description": "The host address of the ScaleIO API Gateway.",
+                                        "description": "gateway is the host address of the ScaleIO API Gateway.",
                                         "type": "string"
                                     },
                                     "protectionDomain": {
-                                        "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+                                        "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
                                         "type": "string"
                                     },
                                     "readOnly": {
-                                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                        "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                                         "type": "boolean"
                                     },
                                     "secretRef": {
@@ -2329,26 +2935,27 @@
                                                 "type": "string"
                                             }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
                                     },
                                     "sslEnabled": {
-                                        "description": "Flag to enable/disable SSL communication with Gateway, default false",
+                                        "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
                                         "type": "boolean"
                                     },
                                     "storageMode": {
-                                        "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+                                        "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
                                         "type": "string"
                                     },
                                     "storagePool": {
-                                        "description": "The ScaleIO Storage Pool associated with the protection domain.",
+                                        "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
                                         "type": "string"
                                     },
                                     "system": {
-                                        "description": "The name of the storage system as configured in ScaleIO.",
+                                        "description": "system is the name of the storage system as configured in ScaleIO.",
                                         "type": "string"
                                     },
                                     "volumeName": {
-                                        "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+                                        "description": "volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.",
                                         "type": "string"
                                     }
                                 },
@@ -2363,26 +2970,26 @@
                                 "description": "Adapts a Secret into a volume.\n\nThe contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.",
                                 "properties": {
                                     "defaultMode": {
-                                        "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                        "description": "defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                         "format": "int32",
                                         "type": "integer"
                                     },
                                     "items": {
-                                        "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                        "description": "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
                                         "items": {
                                             "description": "Maps a string key to a path within a volume.",
                                             "properties": {
                                                 "key": {
-                                                    "description": "The key to project.",
+                                                    "description": "key is the key to project.",
                                                     "type": "string"
                                                 },
                                                 "mode": {
-                                                    "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                    "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
                                                     "format": "int32",
                                                     "type": "integer"
                                                 },
                                                 "path": {
-                                                    "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                    "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                                                     "type": "string"
                                                 }
                                             },
@@ -2395,11 +3002,11 @@
                                         "type": "array"
                                     },
                                     "optional": {
-                                        "description": "Specify whether the Secret or its keys must be defined",
+                                        "description": "optional field specify whether the Secret or its keys must be defined",
                                         "type": "boolean"
                                     },
                                     "secretName": {
-                                        "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                                        "description": "secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
                                         "type": "string"
                                     }
                                 },
@@ -2409,11 +3016,11 @@
                                 "description": "Represents a StorageOS persistent volume resource.",
                                 "properties": {
                                     "fsType": {
-                                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                        "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                                         "type": "string"
                                     },
                                     "readOnly": {
-                                        "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                        "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
                                         "type": "boolean"
                                     },
                                     "secretRef": {
@@ -2424,14 +3031,15 @@
                                                 "type": "string"
                                             }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
                                     },
                                     "volumeName": {
-                                        "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+                                        "description": "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
                                         "type": "string"
                                     },
                                     "volumeNamespace": {
-                                        "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+                                        "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
                                         "type": "string"
                                     }
                                 },
@@ -2441,19 +3049,19 @@
                                 "description": "Represents a vSphere volume resource.",
                                 "properties": {
                                     "fsType": {
-                                        "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                        "description": "fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                                         "type": "string"
                                     },
                                     "storagePolicyID": {
-                                        "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                                        "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
                                         "type": "string"
                                     },
                                     "storagePolicyName": {
-                                        "description": "Storage Policy Based Management (SPBM) profile name.",
+                                        "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
                                         "type": "string"
                                     },
                                     "volumePath": {
-                                        "description": "Path that identifies vSphere volume vmdk",
+                                        "description": "volumePath is the path that identifies vSphere volume vmdk",
                                         "type": "string"
                                     }
                                 },
@@ -2532,14 +3140,14 @@
                         "description": "A single application container that you want to run within a pod.",
                         "properties": {
                             "args": {
-                                "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                "description": "Arguments to the entrypoint. The container image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
                                 "items": {
                                     "type": "string"
                                 },
                                 "type": "array"
                             },
                             "command": {
-                                "description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                "description": "Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
                                 "items": {
                                     "type": "string"
                                 },
@@ -2555,7 +3163,7 @@
                                             "type": "string"
                                         },
                                         "value": {
-                                            "description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                            "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
                                             "type": "string"
                                         },
                                         "valueFrom": {
@@ -2580,7 +3188,8 @@
                                                     "required": [
                                                         "key"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "fieldRef": {
                                                     "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
@@ -2597,7 +3206,8 @@
                                                     "required": [
                                                         "fieldPath"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "resourceFieldRef": {
                                                     "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
@@ -2624,7 +3234,8 @@
                                                     "required": [
                                                         "resource"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "secretKeyRef": {
                                                     "description": "SecretKeySelector selects a key of a Secret.",
@@ -2645,7 +3256,8 @@
                                                     "required": [
                                                         "key"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic"
                                                 }
                                             },
                                             "type": "object"
@@ -2703,7 +3315,7 @@
                                 "type": "array"
                             },
                             "image": {
-                                "description": "Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                                "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
                                 "type": "string"
                             },
                             "imagePullPolicy": {
@@ -2714,7 +3326,7 @@
                                 "description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
                                 "properties": {
                                     "postStart": {
-                                        "description": "Handler defines a specific action that should be taken",
+                                        "description": "LifecycleHandler defines a specific action that should be taken in a lifecycle hook. One and only one of the fields, except TCPSocket must be specified.",
                                         "properties": {
                                             "exec": {
                                                 "description": "ExecAction describes a \"run in container\" action.",
@@ -2742,7 +3354,7 @@
                                                             "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                                             "properties": {
                                                                 "name": {
-                                                                    "description": "The header field name",
+                                                                    "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                                                     "type": "string"
                                                                 },
                                                                 "value": {
@@ -2779,6 +3391,20 @@
                                                 },
                                                 "required": [
                                                     "port"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "sleep": {
+                                                "description": "SleepAction describes a \"sleep\" action.",
+                                                "properties": {
+                                                    "seconds": {
+                                                        "description": "Seconds is the number of seconds to sleep.",
+                                                        "format": "int64",
+                                                        "type": "integer"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "seconds"
                                                 ],
                                                 "type": "object"
                                             },
@@ -2809,7 +3435,7 @@
                                         "type": "object"
                                     },
                                     "preStop": {
-                                        "description": "Handler defines a specific action that should be taken",
+                                        "description": "LifecycleHandler defines a specific action that should be taken in a lifecycle hook. One and only one of the fields, except TCPSocket must be specified.",
                                         "properties": {
                                             "exec": {
                                                 "description": "ExecAction describes a \"run in container\" action.",
@@ -2837,7 +3463,7 @@
                                                             "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                                             "properties": {
                                                                 "name": {
-                                                                    "description": "The header field name",
+                                                                    "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                                                     "type": "string"
                                                                 },
                                                                 "value": {
@@ -2874,6 +3500,20 @@
                                                 },
                                                 "required": [
                                                     "port"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "sleep": {
+                                                "description": "SleepAction describes a \"sleep\" action.",
+                                                "properties": {
+                                                    "seconds": {
+                                                        "description": "Seconds is the number of seconds to sleep.",
+                                                        "format": "int64",
+                                                        "type": "integer"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "seconds"
                                                 ],
                                                 "type": "object"
                                             },
@@ -2927,6 +3567,23 @@
                                         "format": "int32",
                                         "type": "integer"
                                     },
+                                    "grpc": {
+                                        "properties": {
+                                            "port": {
+                                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                                "format": "int32",
+                                                "type": "integer"
+                                            },
+                                            "service": {
+                                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "port"
+                                        ],
+                                        "type": "object"
+                                    },
                                     "httpGet": {
                                         "description": "HTTPGetAction describes an action based on HTTP Get requests.",
                                         "properties": {
@@ -2940,7 +3597,7 @@
                                                     "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                                     "properties": {
                                                         "name": {
-                                                            "description": "The header field name",
+                                                            "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                                             "type": "string"
                                                         },
                                                         "value": {
@@ -3018,6 +3675,11 @@
                                         ],
                                         "type": "object"
                                     },
+                                    "terminationGracePeriodSeconds": {
+                                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                        "format": "int64",
+                                        "type": "integer"
+                                    },
                                     "timeoutSeconds": {
                                         "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                                         "format": "int32",
@@ -3031,7 +3693,7 @@
                                 "type": "string"
                             },
                             "ports": {
-                                "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+                                "description": "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.",
                                 "items": {
                                     "description": "ContainerPort represents a network port in a single container.",
                                     "properties": {
@@ -3093,6 +3755,23 @@
                                         "format": "int32",
                                         "type": "integer"
                                     },
+                                    "grpc": {
+                                        "properties": {
+                                            "port": {
+                                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                                "format": "int32",
+                                                "type": "integer"
+                                            },
+                                            "service": {
+                                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "port"
+                                        ],
+                                        "type": "object"
+                                    },
                                     "httpGet": {
                                         "description": "HTTPGetAction describes an action based on HTTP Get requests.",
                                         "properties": {
@@ -3106,7 +3785,7 @@
                                                     "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                                     "properties": {
                                                         "name": {
-                                                            "description": "The header field name",
+                                                            "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                                             "type": "string"
                                                         },
                                                         "value": {
@@ -3184,6 +3863,11 @@
                                         ],
                                         "type": "object"
                                     },
+                                    "terminationGracePeriodSeconds": {
+                                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                        "format": "int64",
+                                        "type": "integer"
+                                    },
                                     "timeoutSeconds": {
                                         "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                                         "format": "int32",
@@ -3192,9 +3876,53 @@
                                 },
                                 "type": "object"
                             },
+                            "resizePolicy": {
+                                "description": "Resources resize policy for the container.",
+                                "items": {
+                                    "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                                    "properties": {
+                                        "resourceName": {
+                                            "description": "Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.",
+                                            "type": "string"
+                                        },
+                                        "restartPolicy": {
+                                            "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "resourceName",
+                                        "restartPolicy"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                            },
                             "resources": {
                                 "description": "ResourceRequirements describes the compute resource requirements.",
                                 "properties": {
+                                    "claims": {
+                                        "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.\n\nThis is an alpha field and requires enabling the DynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                                        "items": {
+                                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                            "properties": {
+                                                "name": {
+                                                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "name"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-map-keys": [
+                                            "name"
+                                        ],
+                                        "x-kubernetes-list-type": "map"
+                                    },
                                     "limits": {
                                         "additionalProperties": {
                                             "oneOf": [
@@ -3206,7 +3934,7 @@
                                                 }
                                             ]
                                         },
-                                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                                         "type": "object"
                                     },
                                     "requests": {
@@ -3220,17 +3948,21 @@
                                                 }
                                             ]
                                         },
-                                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                                         "type": "object"
                                     }
                                 },
                                 "type": "object"
                             },
+                            "restartPolicy": {
+                                "description": "RestartPolicy defines the restart behavior of individual containers in a pod. This field may only be set for init containers, and the only allowed value is \"Always\". For non-init containers or when this field is not specified, the restart behavior is defined by the Pod's restart policy and the container type. Setting the RestartPolicy as \"Always\" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy \"Always\" will be shut down. This lifecycle differs from normal init containers and is often referred to as a \"sidecar\" container. Although this init container still starts in the init container sequence, it does not wait for the container to complete before proceeding to the next init container. Instead, the next init container starts immediately after this init container is started, or after any startupProbe has successfully completed.",
+                                "type": "string"
+                            },
                             "securityContext": {
                                 "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
                                 "properties": {
                                     "allowPrivilegeEscalation": {
-                                        "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+                                        "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
                                         "type": "boolean"
                                     },
                                     "capabilities": {
@@ -3254,19 +3986,19 @@
                                         "type": "object"
                                     },
                                     "privileged": {
-                                        "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+                                        "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
                                         "type": "boolean"
                                     },
                                     "procMount": {
-                                        "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+                                        "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
                                         "type": "string"
                                     },
                                     "readOnlyRootFilesystem": {
-                                        "description": "Whether this container has a read-only root filesystem. Default is false.",
+                                        "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
                                         "type": "boolean"
                                     },
                                     "runAsGroup": {
-                                        "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                        "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
                                         "format": "int64",
                                         "type": "integer"
                                     },
@@ -3275,7 +4007,7 @@
                                         "type": "boolean"
                                     },
                                     "runAsUser": {
-                                        "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                        "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
                                         "format": "int64",
                                         "type": "integer"
                                     },
@@ -3301,6 +4033,31 @@
                                         },
                                         "type": "object"
                                     },
+                                    "seccompProfile": {
+                                        "description": "SeccompProfile defines a pod/container's seccomp profile settings. Only one profile source may be set.",
+                                        "properties": {
+                                            "localhostProfile": {
+                                                "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "description": "type indicates which kind of seccomp profile will be applied. Valid options are:\n\nLocalhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "type"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-unions": [
+                                            {
+                                                "discriminator": "type",
+                                                "fields-to-discriminateBy": {
+                                                    "localhostProfile": "LocalhostProfile"
+                                                }
+                                            }
+                                        ]
+                                    },
                                     "windowsOptions": {
                                         "description": "WindowsSecurityContextOptions contain Windows-specific options and credentials.",
                                         "properties": {
@@ -3311,6 +4068,10 @@
                                             "gmsaCredentialSpecName": {
                                                 "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                                                 "type": "string"
+                                            },
+                                            "hostProcess": {
+                                                "description": "HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                                "type": "boolean"
                                             },
                                             "runAsUserName": {
                                                 "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
@@ -3343,6 +4104,23 @@
                                         "format": "int32",
                                         "type": "integer"
                                     },
+                                    "grpc": {
+                                        "properties": {
+                                            "port": {
+                                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                                "format": "int32",
+                                                "type": "integer"
+                                            },
+                                            "service": {
+                                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "port"
+                                        ],
+                                        "type": "object"
+                                    },
                                     "httpGet": {
                                         "description": "HTTPGetAction describes an action based on HTTP Get requests.",
                                         "properties": {
@@ -3356,7 +4134,7 @@
                                                     "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                                     "properties": {
                                                         "name": {
-                                                            "description": "The header field name",
+                                                            "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                                             "type": "string"
                                                         },
                                                         "value": {
@@ -3433,6 +4211,11 @@
                                             "port"
                                         ],
                                         "type": "object"
+                                    },
+                                    "terminationGracePeriodSeconds": {
+                                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                        "format": "int64",
+                                        "type": "integer"
                                     },
                                     "timeoutSeconds": {
                                         "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
@@ -3565,6 +4348,23 @@
                             "format": "int32",
                             "type": "integer"
                         },
+                        "grpc": {
+                            "properties": {
+                                "port": {
+                                    "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                },
+                                "service": {
+                                    "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "port"
+                            ],
+                            "type": "object"
+                        },
                         "httpGet": {
                             "description": "HTTPGetAction describes an action based on HTTP Get requests.",
                             "properties": {
@@ -3578,7 +4378,7 @@
                                         "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                         "properties": {
                                             "name": {
-                                                "description": "The header field name",
+                                                "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                                 "type": "string"
                                             },
                                             "value": {
@@ -3655,6 +4455,11 @@
                                 "port"
                             ],
                             "type": "object"
+                        },
+                        "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "format": "int64",
+                            "type": "integer"
                         },
                         "timeoutSeconds": {
                             "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
@@ -3693,7 +4498,7 @@
                     "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
                     "properties": {
                         "allowPrivilegeEscalation": {
-                            "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+                            "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
                             "type": "boolean"
                         },
                         "capabilities": {
@@ -3717,19 +4522,19 @@
                             "type": "object"
                         },
                         "privileged": {
-                            "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+                            "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
                             "type": "boolean"
                         },
                         "procMount": {
-                            "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+                            "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
                             "type": "string"
                         },
                         "readOnlyRootFilesystem": {
-                            "description": "Whether this container has a read-only root filesystem. Default is false.",
+                            "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
                             "type": "boolean"
                         },
                         "runAsGroup": {
-                            "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
                             "format": "int64",
                             "type": "integer"
                         },
@@ -3738,7 +4543,7 @@
                             "type": "boolean"
                         },
                         "runAsUser": {
-                            "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
                             "format": "int64",
                             "type": "integer"
                         },
@@ -3764,6 +4569,31 @@
                             },
                             "type": "object"
                         },
+                        "seccompProfile": {
+                            "description": "SeccompProfile defines a pod/container's seccomp profile settings. Only one profile source may be set.",
+                            "properties": {
+                                "localhostProfile": {
+                                    "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "description": "type indicates which kind of seccomp profile will be applied. Valid options are:\n\nLocalhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "type"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-unions": [
+                                {
+                                    "discriminator": "type",
+                                    "fields-to-discriminateBy": {
+                                        "localhostProfile": "LocalhostProfile"
+                                    }
+                                }
+                            ]
+                        },
                         "windowsOptions": {
                             "description": "WindowsSecurityContextOptions contain Windows-specific options and credentials.",
                             "properties": {
@@ -3774,6 +4604,10 @@
                                 "gmsaCredentialSpecName": {
                                     "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                                     "type": "string"
+                                },
+                                "hostProcess": {
+                                    "description": "HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                    "type": "boolean"
                                 },
                                 "runAsUserName": {
                                     "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
@@ -3806,6 +4640,23 @@
                             "format": "int32",
                             "type": "integer"
                         },
+                        "grpc": {
+                            "properties": {
+                                "port": {
+                                    "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                },
+                                "service": {
+                                    "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "port"
+                            ],
+                            "type": "object"
+                        },
                         "httpGet": {
                             "description": "HTTPGetAction describes an action based on HTTP Get requests.",
                             "properties": {
@@ -3819,7 +4670,7 @@
                                         "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                         "properties": {
                                             "name": {
-                                                "description": "The header field name",
+                                                "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                                 "type": "string"
                                             },
                                             "value": {
@@ -3897,6 +4748,11 @@
                             ],
                             "type": "object"
                         },
+                        "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "format": "int64",
+                            "type": "integer"
+                        },
                         "timeoutSeconds": {
                             "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
@@ -3914,6 +4770,27 @@
                 "resources": {
                     "description": "ResourceRequirements describes the compute resource requirements.",
                     "properties": {
+                        "claims": {
+                            "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.\n\nThis is an alpha field and requires enabling the DynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                            "items": {
+                                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                "properties": {
+                                    "name": {
+                                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name"
+                                ],
+                                "type": "object"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-map-keys": [
+                                "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
+                        },
                         "limits": {
                             "additionalProperties": {
                                 "oneOf": [
@@ -3925,7 +4802,7 @@
                                     }
                                 ]
                             },
-                            "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                            "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                             "type": "object"
                         },
                         "requests": {
@@ -3939,7 +4816,7 @@
                                     }
                                 ]
                             },
-                            "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                            "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                             "type": "object"
                         }
                     },
@@ -3972,6 +4849,23 @@
                             "format": "int32",
                             "type": "integer"
                         },
+                        "grpc": {
+                            "properties": {
+                                "port": {
+                                    "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                },
+                                "service": {
+                                    "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "port"
+                            ],
+                            "type": "object"
+                        },
                         "httpGet": {
                             "description": "HTTPGetAction describes an action based on HTTP Get requests.",
                             "properties": {
@@ -3985,7 +4879,7 @@
                                         "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                         "properties": {
                                             "name": {
-                                                "description": "The header field name",
+                                                "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                                 "type": "string"
                                             },
                                             "value": {
@@ -4062,6 +4956,11 @@
                                 "port"
                             ],
                             "type": "object"
+                        },
+                        "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "format": "int64",
+                            "type": "integer"
                         },
                         "timeoutSeconds": {
                             "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
@@ -4641,9 +5540,7 @@
                                         "properties": {
                                             "key": {
                                                 "description": "key is the label key that the selector applies to.",
-                                                "type": "string",
-                                                "x-kubernetes-patch-merge-key": "key",
-                                                "x-kubernetes-patch-strategy": "merge"
+                                                "type": "string"
                                             },
                                             "operator": {
                                                 "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
@@ -4673,7 +5570,8 @@
                                     "type": "object"
                                 }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic"
                         },
                         "podSelector": {
                             "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
@@ -4685,9 +5583,7 @@
                                         "properties": {
                                             "key": {
                                                 "description": "key is the label key that the selector applies to.",
-                                                "type": "string",
-                                                "x-kubernetes-patch-merge-key": "key",
-                                                "x-kubernetes-patch-strategy": "merge"
+                                                "type": "string"
                                             },
                                             "operator": {
                                                 "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
@@ -4717,7 +5613,8 @@
                                     "type": "object"
                                 }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic"
                         }
                     },
                     "title": "Custom egress rules for the network policy",

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -287,7 +287,7 @@
                     "title": "Deployment sidecars.",
                     "type": "array",
                     "items": {
-                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
+                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
                     },
                     "default": []
                 },
@@ -295,7 +295,7 @@
                     "title": "Backstage container environment variables",
                     "type": "array",
                     "items": {
-                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar"
+                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar"
                     },
                     "default": [],
                     "examples": [
@@ -325,7 +325,7 @@
                     "title": "Backstage container additional volume mounts",
                     "type": "array",
                     "items": {
-                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount"
+                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount"
                     },
                     "default": []
                 },
@@ -333,7 +333,7 @@
                     "title": "Backstage container additional volumes",
                     "type": "array",
                     "items": {
-                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
+                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
                     },
                     "default": []
                 },
@@ -341,7 +341,7 @@
                     "title": "Backstage container init containers",
                     "type": "array",
                     "items": {
-                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
+                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
                     },
                     "default": []
                 },
@@ -353,7 +353,7 @@
                 "resources": {
                     "title": "Resource requests/limits",
                     "description": "Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container",
-                    "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
                     "default": {},
                     "examples": [
                         {
@@ -371,7 +371,7 @@
                 "readinessProbe": {
                     "title": "Readiness probe",
                     "description": "Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/",
-                    "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
                     "default": {},
                     "examples": [
                         {
@@ -391,7 +391,7 @@
                 "livenessProbe": {
                     "title": "Liveness probe",
                     "description": "Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/",
-                    "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
                     "default": {},
                     "examples": [
                         {
@@ -411,7 +411,7 @@
                 "startupProbe": {
                     "title": "Startup probe",
                     "description": "Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/",
-                    "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
                     "default": {},
                     "examples": [
                         {
@@ -431,13 +431,13 @@
                 "podSecurityContext": {
                     "title": "Security settings for a Pod.",
                     "description": "The security settings that you specify for a Pod apply to all Containers in the Pod. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod",
-                    "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
                     "default": {}
                 },
                 "containerSecurityContext": {
                     "title": "Security settings for a Container.",
                     "description": "Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container",
-                    "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
                     "default": {}
                 },
                 "appConfig": {
@@ -469,7 +469,7 @@
                     "description": "Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/",
                     "type": "array",
                     "items": {
-                        "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.Toleration"
+                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.Toleration"
                     },
                     "default": []
                 },
@@ -640,13 +640,13 @@
                         "namespaceSelector": {
                             "title": "Namespace Selector.",
                             "description": "Selects Namespaces using cluster scoped-labels.",
-                            "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
                             "default": {}
                         },
                         "podSelector": {
                             "title": "Pod Selector.",
                             "description": "Selects selects Pods in this namespace.",
-                            "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
                             "default": {}
                         }
                     }


### PR DESCRIPTION
## Description

In the values schema, the references to `kubernetes` definitions point to a rather old and obsolete schema (not updated since 3 years): https://github.com/instrumenta/kubernetes-json-schema

This PR proposes to switch to the following fork of the previous repository, which provides up-to-date `kubernetes` schemas: https://github.com/yannh/kubernetes-json-schema#readme

This will allow using recent Kubernetes features like [Generic Ephemeral Volumes](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes) 

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
