### PR TITLE
Add support for external configmaps using backstage.extraEnvVarsCM

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.1
+version: 1.7.0

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 1.6.1](https://img.shields.io/badge/Version-1.6.1-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
@@ -123,7 +123,8 @@ Kubernetes: `>= 1.19.0-0`
 | backstage.extraAppConfig | Extra app configuration files to inline into command arguments | list | `[]` |
 | backstage.extraContainers | Deployment sidecars | list | `[]` |
 | backstage.extraEnvVars | Backstage container environment variables | list | `[]` |
-| backstage.extraEnvVarsSecrets | Backstage container environment variables from Secrets | list | `[]` |
+| backstage.extraEnvVarsCM | Backstage container environment variables from existing ConfigMaps | list | `[]` |
+| backstage.extraEnvVarsSecrets | Backstage container environment variables from existing Secrets | list | `[]` |
 | backstage.extraVolumeMounts | Backstage container additional volume mounts | list | `[]` |
 | backstage.extraVolumes | Backstage container additional volumes | list | `[]` |
 | backstage.image.debug | Set to true if you would like to see extra information on logs | bool | `false` |

--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -116,8 +116,12 @@ spec:
           {{- if .Values.backstage.startupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.backstage.startupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.backstage.extraEnvVarsSecrets }}
+          {{- if (or .Values.backstage.extraEnvVarsCM .Values.backstage.extraEnvVarsSecrets) }}
           envFrom:
+            {{- range .Values.backstage.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ . }}
+            {{- end }}
             {{- range .Values.backstage.extraEnvVarsSecrets }}
             - secretRef:
                 name: {{ . }}

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -1514,6 +1514,20 @@
                     "title": "Backstage container environment variables",
                     "type": "array"
                 },
+                "extraEnvVarsCM": {
+                    "default": [],
+                    "description": "Translates into array of `envFrom.[].configMapRef.name`",
+                    "examples": [
+                        [
+                            "my-backstage-configmap"
+                        ]
+                    ],
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "Backstage container environment variables from existing ConfigMaps",
+                    "type": "array"
+                },
                 "extraEnvVarsSecrets": {
                     "default": [],
                     "description": "Translates into array of `envFrom.[].secretRef.name`",
@@ -1525,7 +1539,7 @@
                     "items": {
                         "type": "string"
                     },
-                    "title": "Backstage container environment variables from Secrets",
+                    "title": "Backstage container environment variables from existing Secrets",
                     "type": "array"
                 },
                 "extraVolumeMounts": {

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -307,8 +307,22 @@
                         ]
                     ]
                 },
+                "extraEnvVarsCM": {
+                    "title": "Backstage container environment variables from existing ConfigMaps",
+                    "type": "array",
+                    "description": "Translates into array of `envFrom.[].configMapRef.name`",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "examples": [
+                        [
+                            "my-backstage-configmap"
+                        ]
+                    ]
+                },
                 "extraEnvVarsSecrets": {
-                    "title": "Backstage container environment variables from Secrets",
+                    "title": "Backstage container environment variables from existing Secrets",
                     "type": "array",
                     "description": "Translates into array of `envFrom.[].secretRef.name`",
                     "items": {

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -131,7 +131,10 @@ backstage:
   # -- Backstage container environment variables
   extraEnvVars: []
 
-  # -- Backstage container environment variables from Secrets
+  # -- Backstage container environment variables from existing ConfigMaps
+  extraEnvVarsCM: []
+
+  # -- Backstage container environment variables from existing Secrets
   extraEnvVarsSecrets: []
 
   # -- Backstage container additional volume mounts


### PR DESCRIPTION
## Description of the change

Adds support to reference external configmaps in the backstage deployment. This is useful if external configuration like e.g. the Postgres database connection values are required from a configmap managed elsewhere.

It's a common pattern that is implemented as standard in all Bitnami Charts. See https://github.com/bitnami/charts/blob/main/template/README.md?plain=1#L27

## Additional Information

I hope I managed to run all commands currently (helm-docs and the python script). A bit more info in the checklist would be helpful (e.g. to check .pre-commit-config.yaml or even the exact commands to run).

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
