### PR TITLE
fix: honor .global.postgresql.auth values

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.0
+version: 1.8.1

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square)
+![Version: 1.8.1](https://img.shields.io/badge/Version-1.8.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application

--- a/charts/backstage/templates/_helpers.tpl
+++ b/charts/backstage/templates/_helpers.tpl
@@ -46,7 +46,9 @@ Return the Postgres Database hostname
 Return the Postgres Database Secret Name
 */}}
 {{- define "backstage.postgresql.databaseSecretName" -}}
-{{- if .Values.postgresql.auth.existingSecret }}
+{{- if ((((.Values).global).postgresql).auth).existingSecret }}
+    {{- tpl .Values.global.postgresql.auth.existingSecret $ -}}
+{{- else if .Values.postgresql.auth.existingSecret }}
     {{- tpl .Values.postgresql.auth.existingSecret $ -}}
 {{- else -}}
     {{- default (include "backstage.postgresql.fullname" .) (tpl .Values.postgresql.auth.existingSecret $) -}}
@@ -57,9 +59,16 @@ Return the Postgres Database Secret Name
 Return the Postgres databaseSecret key to retrieve credentials for database
 */}}
 {{- define "backstage.postgresql.databaseSecretKey" -}}
-{{- if .Values.postgresql.auth.existingSecret -}}
-    {{- .Values.postgresql.auth.secretKeys.userPasswordKey  -}}
+{{- $defaultDatabaseSecretKey := "password" -}}
+{{- if (or ((((.Values).global).postgresql).auth).existingSecret .Values.postgresql.auth.existingSecret) }}
+    {{- if (((((.Values).global).postgresql).auth).secretKeys).userPasswordKey -}}
+        {{- .Values.global.postgresql.auth.secretKeys.userPasswordKey  -}}
+    {{- else if ((((.Values).postgresql).auth).secretKeys).userPasswordKey -}}
+        {{- .Values.postgresql.auth.secretKeys.userPasswordKey  -}}
+    {{- else -}}
+        {{- print $defaultDatabaseSecretKey -}}
+    {{- end -}}
 {{- else -}}
-    {{- print "password" -}}
+    {{- print $defaultDatabaseSecretKey -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

Our dependency - bitnami/postgresql chart has an option to configure `auth` via `global` scope variables. We do not consider that option when we infer secret name and key for the Backstage deployment volume mounts.

This PR adds support for:

1. `.Values.global.postgresql.auth.existingSecret` which overrides `.Values.postgresql.auth.existingSecret`
2. `.Values.global.postgresql.auth.secretKeys.userPasswordKey` which overrides `.Values.postgresql.auth.secretKeys.userPasswordKey` and (either of these) gets applied only if 
`.Values.global.postgresql.auth.existingSecret` or `.Values.postgresql.auth.existingSecret` is defined

I'm using `()` chaining Helm `?.` pipeline notation/workaround so I can avoid declaring those variables as `''` in `values.yaml`


## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
