### PR TITLE
fix: remove unused backstage.debug flag

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.1
+version: 1.8.2

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 1.8.1](https://img.shields.io/badge/Version-1.8.1-informational?style=flat-square)
+![Version: 1.8.2](https://img.shields.io/badge/Version-1.8.2-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
@@ -127,7 +127,6 @@ Kubernetes: `>= 1.19.0-0`
 | backstage.extraEnvVarsSecrets | Backstage container environment variables from existing Secrets | list | `[]` |
 | backstage.extraVolumeMounts | Backstage container additional volume mounts | list | `[]` |
 | backstage.extraVolumes | Backstage container additional volumes | list | `[]` |
-| backstage.image.debug | Set to true if you would like to see extra information on logs | bool | `false` |
 | backstage.image.pullPolicy | Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent' <br /> Ref: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy | string | `"Always"` |
 | backstage.image.pullSecrets | Optionally specify an array of imagePullSecrets.  Secrets must be manually created in the namespace. <br /> Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ <br /> E.g: `pullSecrets: [myRegistryKeySecretName]` | list | `[]` |
 | backstage.image.registry | Backstage image registry | string | `"ghcr.io"` |

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -3096,11 +3096,6 @@
                 "image": {
                     "additionalProperties": false,
                     "properties": {
-                        "debug": {
-                            "default": false,
-                            "title": "Set to true if you would like to see extra information on logs",
-                            "type": "boolean"
-                        },
                         "pullPolicy": {
                             "default": "Always",
                             "description": "Ref: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy",

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -227,11 +227,6 @@
                             "examples": [
                                 "myRegistryKeySecretName"
                             ]
-                        },
-                        "debug": {
-                            "title": "Set to true if you would like to see extra information on logs",
-                            "type": "boolean",
-                            "default": false
                         }
                     }
                 },

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -109,9 +109,6 @@ backstage:
     # <br /> E.g: `pullSecrets: [myRegistryKeySecretName]`
     pullSecrets: []
 
-    # -- Set to true if you would like to see extra information on logs
-    debug: false
-
   # -- Container ports on the Deployment
   containerPorts:
     backend: 7007


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

I've noticed we have a `backstage.debug` flag and it does nothing. It's never used in any of the templates.


## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

Instead of inventing our own solution to a "debug" flag, I think we should just get rid of it and let people use the officially documented https://backstage.io/docs/local-dev/debugging/ env variables.

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
