### PR TITLE
chore: update chart readme to recommend newer versions of Helm (not 3.2)

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.1
+version: 1.9.2

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -44,7 +44,7 @@ This chart bootstraps a [Backstage](https://backstage.io/docs/deployment/docker)
 ## Prerequisites
 
 - Kubernetes 1.19+
-- Helm 3.2.0+
+- Helm 3.10+ minimum, 3.14+ recommended
 - PV provisioner support in the underlying infrastructure
 - [Backstage container image](https://backstage.io/docs/deployment/docker)
 

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 1.9.1](https://img.shields.io/badge/Version-1.9.1-informational?style=flat-square)
+![Version: 1.9.2](https://img.shields.io/badge/Version-1.9.2-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -43,7 +43,7 @@ This chart bootstraps a [Backstage](https://backstage.io/docs/deployment/docker)
 
 ## Prerequisites
 
-- Kubernetes 1.19+
+- Kubernetes 1.25+
 - Helm 3.10+ minimum, 3.14+ recommended
 - PV provisioner support in the underlying infrastructure
 - [Backstage container image](https://backstage.io/docs/deployment/docker)

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -38,7 +38,7 @@ This chart bootstraps a [Backstage](https://backstage.io/docs/deployment/docker)
 ## Prerequisites
 
 - Kubernetes 1.19+
-- Helm 3.2.0+
+- Helm 3.10+ minimum, 3.14+ recommended
 - PV provisioner support in the underlying infrastructure
 - [Backstage container image](https://backstage.io/docs/deployment/docker)
 

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -37,7 +37,7 @@ This chart bootstraps a [Backstage](https://backstage.io/docs/deployment/docker)
 
 ## Prerequisites
 
-- Kubernetes 1.19+
+- Kubernetes 1.25+
 - Helm 3.10+ minimum, 3.14+ recommended
 - PV provisioner support in the underlying infrastructure
 - [Backstage container image](https://backstage.io/docs/deployment/docker)

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -822,6 +822,31 @@
                             "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
                             "type": "boolean"
                         },
+                        "appArmorProfile": {
+                            "description": "AppArmorProfile defines a pod or container's AppArmor settings.",
+                            "properties": {
+                                "localhostProfile": {
+                                    "description": "localhostProfile indicates a profile loaded on the node that should be used. The profile must be preconfigured on the node to work. Must match the loaded name of the profile. Must be set if and only if type is \"Localhost\".",
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "description": "type indicates which kind of AppArmor profile will be applied. Valid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "type"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-unions": [
+                                {
+                                    "discriminator": "type",
+                                    "fields-to-discriminateBy": {
+                                        "localhostProfile": "LocalhostProfile"
+                                    }
+                                }
+                            ]
+                        },
                         "capabilities": {
                             "description": "Adds and removes POSIX capabilities from running containers.",
                             "properties": {
@@ -1804,6 +1829,31 @@
                                     "allowPrivilegeEscalation": {
                                         "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
                                         "type": "boolean"
+                                    },
+                                    "appArmorProfile": {
+                                        "description": "AppArmorProfile defines a pod or container's AppArmor settings.",
+                                        "properties": {
+                                            "localhostProfile": {
+                                                "description": "localhostProfile indicates a profile loaded on the node that should be used. The profile must be preconfigured on the node to work. Must match the loaded name of the profile. Must be set if and only if type is \"Localhost\".",
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "description": "type indicates which kind of AppArmor profile will be applied. Valid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "type"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-unions": [
+                                            {
+                                                "discriminator": "type",
+                                                "fields-to-discriminateBy": {
+                                                    "localhostProfile": "LocalhostProfile"
+                                                }
+                                            }
+                                        ]
                                     },
                                     "capabilities": {
                                         "description": "Adds and removes POSIX capabilities from running containers.",
@@ -3025,7 +3075,7 @@
                                                         "type": "string"
                                                     },
                                                     "volumeAttributesClassName": {
-                                                        "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim. If specified, the CSI driver will create or update the volume with the attributes defined in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName, it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass will be applied to the claim but it's not allowed to reset this field to empty string once it is set. If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass will be set by the persistentvolume controller if it exists. If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.",
+                                                        "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim. If specified, the CSI driver will create or update the volume with the attributes defined in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName, it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass will be applied to the claim but it's not allowed to reset this field to empty string once it is set. If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass will be set by the persistentvolume controller if it exists. If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/ (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.",
                                                         "type": "string"
                                                     },
                                                     "volumeMode": {
@@ -4798,6 +4848,31 @@
                                         "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
                                         "type": "boolean"
                                     },
+                                    "appArmorProfile": {
+                                        "description": "AppArmorProfile defines a pod or container's AppArmor settings.",
+                                        "properties": {
+                                            "localhostProfile": {
+                                                "description": "localhostProfile indicates a profile loaded on the node that should be used. The profile must be preconfigured on the node to work. Must match the loaded name of the profile. Must be set if and only if type is \"Localhost\".",
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "description": "type indicates which kind of AppArmor profile will be applied. Valid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "type"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-unions": [
+                                            {
+                                                "discriminator": "type",
+                                                "fields-to-discriminateBy": {
+                                                    "localhostProfile": "LocalhostProfile"
+                                                }
+                                            }
+                                        ]
+                                    },
                                     "capabilities": {
                                         "description": "Adds and removes POSIX capabilities from running containers.",
                                         "properties": {
@@ -5347,6 +5422,31 @@
                         "allowPrivilegeEscalation": {
                             "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
                             "type": "boolean"
+                        },
+                        "appArmorProfile": {
+                            "description": "AppArmorProfile defines a pod or container's AppArmor settings.",
+                            "properties": {
+                                "localhostProfile": {
+                                    "description": "localhostProfile indicates a profile loaded on the node that should be used. The profile must be preconfigured on the node to work. Must match the loaded name of the profile. Must be set if and only if type is \"Localhost\".",
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "description": "type indicates which kind of AppArmor profile will be applied. Valid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "type"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-unions": [
+                                {
+                                    "discriminator": "type",
+                                    "fields-to-discriminateBy": {
+                                        "localhostProfile": "LocalhostProfile"
+                                    }
+                                }
+                            ]
                         },
                         "capabilities": {
                             "description": "Adds and removes POSIX capabilities from running containers.",


### PR DESCRIPTION
chore: update chart readme to recommend newer versions of Helm (not 3.2)

Signed-off-by: Nick Boldt <nboldt@redhat.com>

For context:

> The documentation for deploying RHDH is missing information for both upstream (backstage/chart) and backstage-showcase docs regarding the required Helm CLI version. This has led to parsing errors during deployment, particularly with Helm 3.6.

> As per the discussion with [Tomas Kral](https://github.com/kadel) suggested fix: 
* To include a section in both upstream ([backstage/chart](https://github.com/backstage/charts)) and 
* [backstage-showcase](https://github.com/janus-idp/backstage-showcase/blob/main/showcase-docs/helm-chart.md) docs  specifying the minimum required Helm CLI version for deployment. 

The recommended version is  last stable version (3.13) and minimum version should be 3.10.
