### PR TITLE
feat: add support for pod affinity

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.4
+version: 1.9.0

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.3
+version: 1.8.4

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 1.8.3](https://img.shields.io/badge/Version-1.8.3-informational?style=flat-square)
+![Version: 1.8.4](https://img.shields.io/badge/Version-1.8.4-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 1.8.4](https://img.shields.io/badge/Version-1.8.4-informational?style=flat-square)
+![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -114,6 +114,7 @@ Kubernetes: `>= 1.19.0-0`
 | Key | Description | Type | Default |
 |-----|-------------|------|---------|
 | backstage | Backstage parameters | object | See below |
+| backstage.affinity | Affinity for pod assignment | object | `{}` |
 | backstage.annotations | Additional custom annotations for the `Deployment` resource | object | `{}` |
 | backstage.appConfig | Generates ConfigMap and configures it in the Backstage pods | object | `{}` |
 | backstage.args | Backstage container command arguments | list | `[]` |

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -114,7 +114,7 @@ Kubernetes: `>= 1.19.0-0`
 | Key | Description | Type | Default |
 |-----|-------------|------|---------|
 | backstage | Backstage parameters | object | See below |
-| backstage.affinity | Affinity for pod assignment | object | `{}` |
+| backstage.affinity | Affinity for pod assignment <br /> Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity | object | `{}` |
 | backstage.annotations | Additional custom annotations for the `Deployment` resource | object | `{}` |
 | backstage.appConfig | Generates ConfigMap and configures it in the Backstage pods | object | `{}` |
 | backstage.args | Backstage container command arguments | list | `[]` |

--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -43,6 +43,10 @@ spec:
       securityContext:
         {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.backstage.affinity }}
+      affinity:
+        {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.affinity "context" $) | nindent 8 }}
+      {{- end }}
       {{- if .Values.backstage.nodeSelector }}
       nodeSelector:
         {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.nodeSelector "context" $) | nindent 8 }}

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -4,6 +4,12 @@
         "backstage": {
             "additionalProperties": false,
             "properties": {
+                "affinity": {
+                    "default": {},
+                    "description": "Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity",
+                    "title": "Affinity for pod assignment",
+                    "type": "object"
+                },
                 "annotations": {
                     "additionalProperties": {
                         "type": "string"

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -7,6 +7,757 @@
                 "affinity": {
                     "default": {},
                     "description": "Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity",
+                    "properties": {
+                        "nodeAffinity": {
+                            "description": "Node affinity is a group of node affinity scheduling rules.",
+                            "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                    "items": {
+                                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                        "properties": {
+                                            "preference": {
+                                                "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "A list of node selector requirements by node's labels.",
+                                                        "items": {
+                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array",
+                                                                    "x-kubernetes-list-type": "atomic"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "matchFields": {
+                                                        "description": "A list of node selector requirements by node's fields.",
+                                                        "items": {
+                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array",
+                                                                    "x-kubernetes-list-type": "atomic"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "weight": {
+                                                "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                                "format": "int32",
+                                                "type": "integer"
+                                            }
+                                        },
+                                        "required": [
+                                            "weight",
+                                            "preference"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.",
+                                    "properties": {
+                                        "nodeSelectorTerms": {
+                                            "description": "Required. A list of node selector terms. The terms are ORed.",
+                                            "items": {
+                                                "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "A list of node selector requirements by node's labels.",
+                                                        "items": {
+                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array",
+                                                                    "x-kubernetes-list-type": "atomic"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "matchFields": {
+                                                        "description": "A list of node selector requirements by node's fields.",
+                                                        "items": {
+                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array",
+                                                                    "x-kubernetes-list-type": "atomic"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                        }
+                                    },
+                                    "required": [
+                                        "nodeSelectorTerms"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "podAffinity": {
+                            "description": "Pod affinity is a group of inter pod affinity scheduling rules.",
+                            "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                    "items": {
+                                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                        "properties": {
+                                            "podAffinityTerm": {
+                                                "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                                "properties": {
+                                                    "labelSelector": {
+                                                        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                                        "properties": {
+                                                            "matchExpressions": {
+                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the label key that the selector applies to.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array",
+                                                                            "x-kubernetes-list-type": "atomic"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array",
+                                                                "x-kubernetes-list-type": "atomic"
+                                                            },
+                                                            "matchLabels": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic"
+                                                    },
+                                                    "matchLabelKeys": {
+                                                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both matchLabelKeys and labelSelector. Also, matchLabelKeys cannot be set when labelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "mismatchLabelKeys": {
+                                                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both mismatchLabelKeys and labelSelector. Also, mismatchLabelKeys cannot be set when labelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "namespaceSelector": {
+                                                        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                                        "properties": {
+                                                            "matchExpressions": {
+                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the label key that the selector applies to.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array",
+                                                                            "x-kubernetes-list-type": "atomic"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array",
+                                                                "x-kubernetes-list-type": "atomic"
+                                                            },
+                                                            "matchLabels": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic"
+                                                    },
+                                                    "namespaces": {
+                                                        "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "topologyKey": {
+                                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "topologyKey"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "weight": {
+                                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                "format": "int32",
+                                                "type": "integer"
+                                            }
+                                        },
+                                        "required": [
+                                            "weight",
+                                            "podAffinityTerm"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                    "items": {
+                                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                        "properties": {
+                                            "labelSelector": {
+                                                "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                        "items": {
+                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array",
+                                                                    "x-kubernetes-list-type": "atomic"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "matchLabels": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "matchLabelKeys": {
+                                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both matchLabelKeys and labelSelector. Also, matchLabelKeys cannot be set when labelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "mismatchLabelKeys": {
+                                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both mismatchLabelKeys and labelSelector. Also, mismatchLabelKeys cannot be set when labelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "namespaceSelector": {
+                                                "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                        "items": {
+                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array",
+                                                                    "x-kubernetes-list-type": "atomic"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "matchLabels": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "namespaces": {
+                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "topologyKey": {
+                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "topologyKey"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "podAntiAffinity": {
+                            "description": "Pod anti affinity is a group of inter pod anti affinity scheduling rules.",
+                            "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                    "items": {
+                                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                        "properties": {
+                                            "podAffinityTerm": {
+                                                "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                                "properties": {
+                                                    "labelSelector": {
+                                                        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                                        "properties": {
+                                                            "matchExpressions": {
+                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the label key that the selector applies to.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array",
+                                                                            "x-kubernetes-list-type": "atomic"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array",
+                                                                "x-kubernetes-list-type": "atomic"
+                                                            },
+                                                            "matchLabels": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic"
+                                                    },
+                                                    "matchLabelKeys": {
+                                                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both matchLabelKeys and labelSelector. Also, matchLabelKeys cannot be set when labelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "mismatchLabelKeys": {
+                                                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both mismatchLabelKeys and labelSelector. Also, mismatchLabelKeys cannot be set when labelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "namespaceSelector": {
+                                                        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                                        "properties": {
+                                                            "matchExpressions": {
+                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the label key that the selector applies to.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array",
+                                                                            "x-kubernetes-list-type": "atomic"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array",
+                                                                "x-kubernetes-list-type": "atomic"
+                                                            },
+                                                            "matchLabels": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic"
+                                                    },
+                                                    "namespaces": {
+                                                        "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "topologyKey": {
+                                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "topologyKey"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "weight": {
+                                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                "format": "int32",
+                                                "type": "integer"
+                                            }
+                                        },
+                                        "required": [
+                                            "weight",
+                                            "podAffinityTerm"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                    "items": {
+                                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                        "properties": {
+                                            "labelSelector": {
+                                                "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                        "items": {
+                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array",
+                                                                    "x-kubernetes-list-type": "atomic"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "matchLabels": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "matchLabelKeys": {
+                                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both matchLabelKeys and labelSelector. Also, matchLabelKeys cannot be set when labelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "mismatchLabelKeys": {
+                                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both mismatchLabelKeys and labelSelector. Also, mismatchLabelKeys cannot be set when labelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "namespaceSelector": {
+                                                "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                        "items": {
+                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array",
+                                                                    "x-kubernetes-list-type": "atomic"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "matchLabels": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "namespaces": {
+                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "topologyKey": {
+                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "topologyKey"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
                     "title": "Affinity for pod assignment",
                     "type": "object"
                 },

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -253,6 +253,26 @@
                         "packages/backend"
                     ]
                 },
+                "affinity": {
+                    "default": {},
+                    "description": "Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity",
+                    "properties": {
+                        "nodeAffinity": {
+                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.NodeAffinity",
+                            "description": "Describes node affinity scheduling rules for the pod."
+                        },
+                        "podAffinity": {
+                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.PodAffinity",
+                            "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s))."
+                        },
+                        "podAntiAffinity": {
+                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.PodAntiAffinity",
+                            "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s))."
+                        }
+                    },
+                    "title": "Affinity for pod assignment",
+                    "type": "object"
+                },
                 "args": {
                     "title": "Backstage container command arguments",
                     "type": "array",

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -225,6 +225,10 @@ backstage:
   # -- Generates ConfigMap and configures it in the Backstage pods
   appConfig: {}
 
+  # -- Affinity for pod assignment
+  # <br /> Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+
   # -- Node labels for pod assignment
   # <br /> Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector: {}


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

Adds support for pod affinity

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

output of `helm template --values=values.yaml .` before and after adding this feature is exactly the same

output after defining affinity in values works as expected:
``` 
      annotations:
        checksum/app-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
    spec:
      serviceAccountName: default
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: my-nodegroup
                operator: In
                values:
                - backstage
      volumes:
```

## Checklist

- [X ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
