### PR TITLE
Add stale workflow

### DIFF
--- a/.github/workflows/automate_stale.yml
+++ b/.github/workflows/automate_stale.yml
@@ -1,0 +1,37 @@
+name: Automate staleness
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    permissions:
+      issues: write # for actions/stale to close stale issues
+      pull-requests: write # for actions/stale to close stale PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+        id: stale
+        with:
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs. Thank you
+            for your contributions.
+          days-before-issue-stale: 60
+          days-before-issue-close: 7
+          exempt-issue-labels: after-vacations,will-fix
+          stale-issue-label: stale
+          stale-pr-message: >
+            This PR has been automatically marked as stale because it has not had
+            recent activity from the author. It will be closed if no further activity occurs.
+            If the PR was closed and you want it re-opened, let us know
+            and we'll re-open the PR so that you can continue the contribution!
+          days-before-pr-stale: 7
+          days-before-pr-close: 5
+          exempt-pr-labels: after-vacations,will-fix
+          stale-pr-label: stale
+          operations-per-run: 100


### PR DESCRIPTION
Adding a stale workflow to help maintain repository health and streamline maintenance tasks, aligning with [backstage/backstage](https://github.com/backstage/backstage).