### PR TITLE
fix: add namespace to configmap = .Release.Namespace; bump chart version to 1.9.3; update/regen docs

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.2
+version: 1.9.3

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 1.9.2](https://img.shields.io/badge/Version-1.9.2-informational?style=flat-square)
+![Version: 1.9.3](https://img.shields.io/badge/Version-1.9.3-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application

--- a/charts/backstage/templates/app-config-configmap.yaml
+++ b/charts/backstage/templates/app-config-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "common.names.fullname" . }}-app-config
+  namespace: {{ .Release.Namespace | quote }}
 data:
   app-config.yaml: |
     {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.appConfig "context" $) | nindent 4 }}


### PR DESCRIPTION
fix: add namespace to configmap = .Release.Namespace; bump chart version to 1.9.3; update/regen docs

Signed-off-by: Nick Boldt <nboldt@redhat.com>

Based on proposed changes in #176 from @IronMage but with DCO fixed and more complete [pre-commit hooks](https://github.com/backstage/charts/blob/main/.pre-commit-config.yaml) applied.

```
Run standard RH pre-commit checks........................................Passed
Helm Docs................................................................Passed
jsonschema-dereference...................................................Passed
```

Ref: https://issues.redhat.com/browse/RHIDP-2170