### PR TITLE
Add environment value and set config appropriately

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.5
+version: 1.9.6

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 1.9.5](https://img.shields.io/badge/Version-1.9.5-informational?style=flat-square)
+![Version: 1.9.6](https://img.shields.io/badge/Version-1.9.6-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
@@ -117,7 +117,7 @@ Kubernetes: `>= 1.19.0-0`
 | backstage.annotations | Additional custom annotations for the `Deployment` resource | object | `{}` |
 | backstage.appConfig | Generates ConfigMap and configures it in the Backstage pods | object | `{}` |
 | backstage.args | Backstage container command arguments | list | `[]` |
-| backstage.command | Backstage container command | list | `["node","packages/backend"]` |
+| backstage.command | Backstage container command | list | `["node","packages/backend","--config","app-config.yaml"]` |
 | backstage.containerPorts | Container ports on the Deployment | object | `{"backend":7007}` |
 | backstage.containerSecurityContext | Security settings for a Container. <br /> Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container | object | `{}` |
 | backstage.extraAppConfig | Extra app configuration files to inline into command arguments | list | `[]` |
@@ -152,6 +152,7 @@ Kubernetes: `>= 1.19.0-0`
 | diagnosticMode.args | Args to override all containers in the Deployment | list | `["infinity"]` |
 | diagnosticMode.command | Command to override all containers in the Deployment | list | `["sleep"]` |
 | diagnosticMode.enabled | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | bool | `false` |
+| environment | Deployment environment | string | `"production"` |
 | extraDeploy | Array of extra objects to deploy with the release | list | `[]` |
 | fullnameOverride | String to fully override common.names.fullname | string | `""` |
 | global | Global parameters Global Docker image parameters Please, note that this will override the image parameters, including dependencies, configured to use the global value Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass | object | See below |

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -120,6 +120,7 @@ Kubernetes: `>= 1.19.0-0`
 | backstage.command | Backstage container command | list | `["node","packages/backend","--config","app-config.yaml"]` |
 | backstage.containerPorts | Container ports on the Deployment | object | `{"backend":7007}` |
 | backstage.containerSecurityContext | Security settings for a Container. <br /> Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container | object | `{}` |
+| backstage.environment | Backstage container environment: development, production | string | `"development"` |
 | backstage.extraAppConfig | Extra app configuration files to inline into command arguments | list | `[]` |
 | backstage.extraContainers | Deployment sidecars | list | `[]` |
 | backstage.extraEnvVars | Backstage container environment variables | list | `[]` |
@@ -152,7 +153,6 @@ Kubernetes: `>= 1.19.0-0`
 | diagnosticMode.args | Args to override all containers in the Deployment | list | `["infinity"]` |
 | diagnosticMode.command | Command to override all containers in the Deployment | list | `["sleep"]` |
 | diagnosticMode.enabled | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | bool | `false` |
-| environment | Deployment environment | string | `"production"` |
 | extraDeploy | Array of extra objects to deploy with the release | list | `[]` |
 | fullnameOverride | String to fully override common.names.fullname | string | `""` |
 | global | Global parameters Global Docker image parameters Please, note that this will override the image parameters, including dependencies, configured to use the global value Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass | object | See below |

--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -87,7 +87,7 @@ spec:
           {{- if .Values.diagnosticMode.enabled }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
           {{- else if .Values.backstage.command }}
-          {{- if eq .Values.environment "production" }}
+          {{- if eq .Values.backstage.environment "production" }}
           command: {{- include "common.tplvalues.render" (dict "value" (concat .Values.backstage.command (list "--config" "app-config.production.yaml")) "context" $) | nindent 12 }}
           {{- else }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.backstage.command "context" $) | nindent 12 }}
@@ -138,6 +138,8 @@ spec:
           env:
             - name: APP_CONFIG_backend_listen_port
               value: {{ .Values.backstage.containerPorts.backend | quote }}
+            - name: NODE_ENV
+              value: {{ .Values.backstage.environment | quote }}
             {{- if .Values.postgresql.enabled }}
             - name: POSTGRES_HOST
               value: {{ include "backstage.postgresql.host" . }}

--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -87,7 +87,11 @@ spec:
           {{- if .Values.diagnosticMode.enabled }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
           {{- else if .Values.backstage.command }}
+          {{- if eq .Values.environment "production" }}
+          command: {{- include "common.tplvalues.render" (dict "value" (concat .Values.backstage.command (list "--config" "app-config.production.yaml")) "context" $) | nindent 12 }}
+          {{- else }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.backstage.command "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
 
           {{- if .Values.diagnosticMode.enabled }}

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -967,6 +967,11 @@
                     },
                     "type": "object"
                 },
+                "environment": {
+                    "default": "development",
+                    "title": "Deployment environment",
+                    "type": "string"
+                },
                 "extraAppConfig": {
                     "default": [],
                     "items": {

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -289,6 +289,11 @@
                     },
                     "default": []
                 },
+                "environment": {
+                    "title": "Deployment environment",
+                    "type": "string",
+                    "default": "development"
+                },
                 "extraAppConfig": {
                     "title": "Extra app configuration files to inline into command arguments",
                     "type": "array",

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -38,9 +38,6 @@ commonAnnotations: {}
 # -- Array of extra objects to deploy with the release
 extraDeploy: []
 
-# -- Deployment environment
-environment: production
-
 # -- Enable diagnostic mode in the Deployment
 diagnosticMode:
 
@@ -124,6 +121,9 @@ backstage:
 
   # -- Backstage container command arguments
   args: []
+
+  # -- Backstage container environment: development, production
+  environment: development
 
   # -- Extra app configuration files to inline into command arguments
   extraAppConfig: []

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -38,6 +38,9 @@ commonAnnotations: {}
 # -- Array of extra objects to deploy with the release
 extraDeploy: []
 
+# -- Deployment environment
+environment: production
+
 # -- Enable diagnostic mode in the Deployment
 diagnosticMode:
 
@@ -117,7 +120,7 @@ backstage:
     backend: 7007
 
   # -- Backstage container command
-  command: ["node", "packages/backend"]
+  command: ["node", "packages/backend", "--config", "app-config.yaml"]
 
   # -- Backstage container command arguments
   args: []


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->
By default the `app-config.production.yaml` file is not used in bootup process of backstage. This leads to misconfiguration and confusion (see attached issue). This PR is a no-op for folks who continue to not set `backstage.environment` value, however those using the `production` string will have the config correctly passed in.

## Existing or Associated Issue(s)

<!-- List any related issues. -->
https://github.com/backstage/backstage/issues/25189

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->
It is not strictly required to pass in `--config app-config.yaml` however I felt that being extra verbose would be clearer in this case.

I noticed that the `ct install` tests were failing, even off master, and I believe this is due to the NODE_ENV not being set correctly thus causing the guest auth provider to error out. I now set that env var based on the backstage environment

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
