### PR TITLE
Adds support for hostAliases

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.5
+version: 1.10.0

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 1.9.5](https://img.shields.io/badge/Version-1.9.5-informational?style=flat-square)
+![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
@@ -127,7 +127,7 @@ Kubernetes: `>= 1.19.0-0`
 | backstage.extraEnvVarsSecrets | Backstage container environment variables from existing Secrets | list | `[]` |
 | backstage.extraVolumeMounts | Backstage container additional volume mounts | list | `[]` |
 | backstage.extraVolumes | Backstage container additional volumes | list | `[]` |
-| backstage.hostAliases | Adding entries to a Pod's /etc/hosts file provides Pod-level override of hostname resolution when DNS and other options are not applicable <br /> Ref: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/#adding-additional-entries-with-hostaliases | list | `[]` |
+| backstage.hostAliases | Host Aliases for the pod <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/ | list | `[]` |
 | backstage.image.pullPolicy | Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent' <br /> Ref: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy | string | `"Always"` |
 | backstage.image.pullSecrets | Optionally specify an array of imagePullSecrets.  Secrets must be manually created in the namespace. <br /> Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ <br /> E.g: `pullSecrets: [myRegistryKeySecretName]` | list | `[]` |
 | backstage.image.registry | Backstage image registry | string | `"ghcr.io"` |

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -127,6 +127,7 @@ Kubernetes: `>= 1.19.0-0`
 | backstage.extraEnvVarsSecrets | Backstage container environment variables from existing Secrets | list | `[]` |
 | backstage.extraVolumeMounts | Backstage container additional volume mounts | list | `[]` |
 | backstage.extraVolumes | Backstage container additional volumes | list | `[]` |
+| backstage.hostAliases | Adding entries to a Pod's /etc/hosts file provides Pod-level override of hostname resolution when DNS and other options are not applicable <br /> Ref: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/#adding-additional-entries-with-hostaliases | list | `[]` |
 | backstage.image.pullPolicy | Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent' <br /> Ref: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy | string | `"Always"` |
 | backstage.image.pullSecrets | Optionally specify an array of imagePullSecrets.  Secrets must be manually created in the namespace. <br /> Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ <br /> E.g: `pullSecrets: [myRegistryKeySecretName]` | list | `[]` |
 | backstage.image.registry | Backstage image registry | string | `"ghcr.io"` |

--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -55,6 +55,10 @@ spec:
       tolerations:
         {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.backstage.hostAliases }}
+      hostAliases:
+        {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
       volumes:
         {{- if (or .Values.backstage.extraAppConfig (and .Values.backstage.extraVolumeMounts .Values.backstage.extraVolumes)) }}
         {{- range .Values.backstage.extraAppConfig }}

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -3960,6 +3960,33 @@
                     "title": "Backstage container additional volumes",
                     "type": "array"
                 },
+                "hostAliases": {
+                    "default": [],
+                    "description": "Ref: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/#adding-additional-entries-with-hostaliases",
+                    "items": {
+                        "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.",
+                        "properties": {
+                            "hostnames": {
+                                "description": "Hostnames for the above IP address.",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                            },
+                            "ip": {
+                                "description": "IP address of the host file entry.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "ip"
+                        ],
+                        "type": "object"
+                    },
+                    "title": "Adding entries to a Pod's /etc/hosts file provides Pod-level override of hostname resolution when DNS and other options are not applicable",
+                    "type": "array"
+                },
                 "image": {
                     "additionalProperties": false,
                     "properties": {
@@ -5967,38 +5994,7 @@
                     },
                     "title": "Node tolerations for server scheduling to nodes with taints",
                     "type": "array"
-                },
-                "hostAliases": {
-                    "type": "array",
-                    "items": {
-                        "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.",
-                        "properties": {
-                          "hostnames": {
-                            "description": "Hostnames for the above IP address.",
-                            "items": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "type": [
-                              "array",
-                              "null"
-                            ]
-                          },
-                          "ip": {
-                            "description": "IP address of the host file entry.",
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false,
-                        "$schema": "http://json-schema.org/schema#"
-                    }
-                }          
+                }
             },
             "title": "Backstage parameters",
             "type": "object"

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -5967,7 +5967,38 @@
                     },
                     "title": "Node tolerations for server scheduling to nodes with taints",
                     "type": "array"
-                }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "items": {
+                        "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.",
+                        "properties": {
+                          "hostnames": {
+                            "description": "Hostnames for the above IP address.",
+                            "items": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "type": [
+                              "array",
+                              "null"
+                            ]
+                          },
+                          "ip": {
+                            "description": "IP address of the host file entry.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false,
+                        "$schema": "http://json-schema.org/schema#"
+                    }
+                }          
             },
             "title": "Backstage parameters",
             "type": "object"

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -510,6 +510,15 @@
                     },
                     "default": []
                 },
+                "hostAliases": {
+                    "title": "Adding entries to a Pod's /etc/hosts file provides Pod-level override of hostname resolution when DNS and other options are not applicable",
+                    "description": "Ref: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/#adding-additional-entries-with-hostaliases",
+                    "type": "array",
+                    "items": {
+                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.HostAlias"
+                    },
+                    "default": []
+                },
                 "podAnnotations": {
                     "title": "Annotations to add to the backend deployment pods",
                     "type": "object",

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -244,6 +244,10 @@ backstage:
   #    value: "value"
   #    effect: "NoSchedule|PreferNoSchedule|NoExecute"
 
+  # -- Host Aliases for the pod
+  # <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  hostAliases: []
+
   # -- Annotations to add to the backend deployment pods
   podAnnotations: {}
 


### PR DESCRIPTION
## Description of the change

Adds support for hostAliases

## Existing or Associated Issue(s)

Closes https://github.com/backstage/charts/issues/204

## Additional Information

## Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [X] JSON Schema generated.
- [X] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
