### PR TITLE
feat(backstage): option to pass in image by digest

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.5
+version: 1.9.6

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 1.9.5](https://img.shields.io/badge/Version-1.9.5-informational?style=flat-square)
+![Version: 1.9.6](https://img.shields.io/badge/Version-1.9.6-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
@@ -127,6 +127,7 @@ Kubernetes: `>= 1.19.0-0`
 | backstage.extraEnvVarsSecrets | Backstage container environment variables from existing Secrets | list | `[]` |
 | backstage.extraVolumeMounts | Backstage container additional volume mounts | list | `[]` |
 | backstage.extraVolumes | Backstage container additional volumes | list | `[]` |
+| backstage.image.digest | Backstage image digest (digest takes precedence over image tag) | string | `""` |
 | backstage.image.pullPolicy | Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent' <br /> Ref: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy | string | `"Always"` |
 | backstage.image.pullSecrets | Optionally specify an array of imagePullSecrets.  Secrets must be manually created in the namespace. <br /> Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ <br /> E.g: `pullSecrets: [myRegistryKeySecretName]` | list | `[]` |
 | backstage.image.registry | Backstage image registry | string | `"ghcr.io"` |

--- a/charts/backstage/ci/image-digest-values.yaml
+++ b/charts/backstage/ci/image-digest-values.yaml
@@ -1,0 +1,5 @@
+backstage:
+  image:
+    registry: ghcr.io
+    repository: backstage/backstage
+    digest: "sha256:a384ce618232b5d9908df083e43c294119f4efdc66890d2a8e3bcba9ccd955e9"

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -3963,6 +3963,12 @@
                 "image": {
                     "additionalProperties": false,
                     "properties": {
+                        "digest": {
+                            "default": "",
+                            "description": "digest takes precedence over image tag",
+                            "title": "Backstage image digest",
+                            "type": "string"
+                        },
                         "pullPolicy": {
                             "default": "Always",
                             "description": "Ref: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy",

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -874,7 +874,7 @@
                             "type": "boolean"
                         },
                         "procMount": {
-                            "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                            "description": "procMount denotes the type of proc mount to use for the containers. The default value is Default which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
                             "type": "string"
                         },
                         "readOnlyRootFilesystem": {
@@ -1775,6 +1775,10 @@
                                                 "name": {
                                                     "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
                                                     "type": "string"
+                                                },
+                                                "request": {
+                                                    "description": "Request is the name chosen for a request in the referenced claim. If empty, everything from the claim is made available, otherwise only the result of this request.",
+                                                    "type": "string"
                                                 }
                                             },
                                             "required": [
@@ -1882,7 +1886,7 @@
                                         "type": "boolean"
                                     },
                                     "procMount": {
-                                        "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                                        "description": "procMount denotes the type of proc mount to use for the containers. The default value is Default which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
                                         "type": "string"
                                     },
                                     "readOnlyRootFilesystem": {
@@ -3083,7 +3087,7 @@
                                                         "type": "string"
                                                     },
                                                     "volumeAttributesClassName": {
-                                                        "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim. If specified, the CSI driver will create or update the volume with the attributes defined in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName, it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass will be applied to the claim but it's not allowed to reset this field to empty string once it is set. If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass will be set by the persistentvolume controller if it exists. If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/ (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.",
+                                                        "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim. If specified, the CSI driver will create or update the volume with the attributes defined in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName, it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass will be applied to the claim but it's not allowed to reset this field to empty string once it is set. If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass will be set by the persistentvolume controller if it exists. If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/ (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).",
                                                         "type": "string"
                                                     },
                                                     "volumeMode": {
@@ -3280,6 +3284,20 @@
                                 ],
                                 "type": "object"
                             },
+                            "image": {
+                                "description": "ImageVolumeSource represents a image volume resource.",
+                                "properties": {
+                                    "pullPolicy": {
+                                        "description": "Policy for pulling OCI objects. Possible values are: Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails. Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present. IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
+                                        "type": "string"
+                                    },
+                                    "reference": {
+                                        "description": "Required: Image or artifact reference to be used. Behaves in the same way as pod.spec.containers[*].image. Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            },
                             "iscsi": {
                                 "description": "Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
                                 "properties": {
@@ -3437,9 +3455,9 @@
                                         "type": "integer"
                                     },
                                     "sources": {
-                                        "description": "sources is the list of volume projections",
+                                        "description": "sources is the list of volume projections. Each entry in this list handles one source.",
                                         "items": {
-                                            "description": "Projection that may be projected along with other supported volume types",
+                                            "description": "Projection that may be projected along with other supported volume types. Exactly one of these fields must be set.",
                                             "properties": {
                                                 "clusterTrustBundle": {
                                                     "description": "ClusterTrustBundleProjection describes how to select a set of ClusterTrustBundle objects and project their contents into the pod filesystem.",
@@ -4807,6 +4825,10 @@
                                                 "name": {
                                                     "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
                                                     "type": "string"
+                                                },
+                                                "request": {
+                                                    "description": "Request is the name chosen for a request in the referenced claim. If empty, everything from the claim is made available, otherwise only the result of this request.",
+                                                    "type": "string"
                                                 }
                                             },
                                             "required": [
@@ -4914,7 +4936,7 @@
                                         "type": "boolean"
                                     },
                                     "procMount": {
-                                        "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                                        "description": "procMount denotes the type of proc mount to use for the containers. The default value is Default which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
                                         "type": "string"
                                     },
                                     "readOnlyRootFilesystem": {
@@ -5493,7 +5515,7 @@
                             "type": "boolean"
                         },
                         "procMount": {
-                            "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                            "description": "procMount denotes the type of proc mount to use for the containers. The default value is Default which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
                             "type": "string"
                         },
                         "readOnlyRootFilesystem": {
@@ -5746,6 +5768,10 @@
                                 "properties": {
                                     "name": {
                                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                        "type": "string"
+                                    },
+                                    "request": {
+                                        "description": "Request is the name chosen for a request in the referenced claim. If empty, everything from the claim is made available, otherwise only the result of this request.",
                                         "type": "string"
                                     }
                                 },

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -193,6 +193,12 @@
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
+                        "digest": {
+                            "default": "",
+                            "description": "digest takes precedence over image tag",
+                            "title": "Backstage image digest",
+                            "type": "string"
+                        },
                         "registry": {
                             "title": "Backstage image registry",
                             "type": "string",

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -101,6 +101,9 @@ backstage:
     # -- Backstage image tag (immutable tags are recommended)
     tag: latest
 
+    # -- Backstage image digest (digest takes precedence over image tag)
+    digest: ""
+
     # -- Specify a imagePullPolicy.
     # Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     # <br /> Ref: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy


### PR DESCRIPTION
## Description of the change

Add option to pass image tag by digest (i.e. `sha256:xxx`) instead of image tag. This makes use of already existing support in the [bitnami common templates](https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_images.tpl).

## Existing or Associated Issue(s)

Apologies as this is just updating the `values.yaml` file I haven't opened an issue.

## Additional Information

This is a common issue that gets flagged when auditing kubernetes manifests with tooling like `trivy` or `checkov`. If you need more detail let me know and I can add some examples to the PR description.

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.