### PR TITLE
feat: add support for multiple hosts and tls configurations in ingress

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.6
+version: 1.10.0

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 1.9.6](https://img.shields.io/badge/Version-1.9.6-informational?style=flat-square)
+![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
@@ -158,10 +158,12 @@ Kubernetes: `>= 1.19.0-0`
 | global | Global parameters Global Docker image parameters Please, note that this will override the image parameters, including dependencies, configured to use the global value Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass | object | See below |
 | global.imagePullSecrets | Global Docker registry secret names as an array </br> E.g. `imagePullSecrets: [myRegistryKeySecretName]` | list | `[]` |
 | global.imageRegistry | Global Docker image registry | string | `""` |
-| ingress | Ingress parameters | object | `{"annotations":{},"className":"","enabled":false,"host":"","path":"/","tls":{"enabled":false,"secretName":""}}` |
+| ingress | Ingress parameters | object | `{"annotations":{},"className":"","enabled":false,"extraHosts":[],"extraTls":[],"host":"","path":"/","tls":{"enabled":false,"secretName":""}}` |
 | ingress.annotations | Additional annotations for the Ingress resource | object | `{}` |
 | ingress.className | Name of the IngressClass cluster resource which defines which controller will implement the resource (e.g nginx) | string | `""` |
 | ingress.enabled | Enable the creation of the ingress resource | bool | `false` |
+| ingress.extraHosts | List of additional hostnames to be covered with this ingress record (e.g. a CNAME) <!-- E.g. extraHosts:   - name: backstage.env.example.com     path: / (Optional)     pathType: Prefix (Optional)     port: 7007 (Optional) --> | list | `[]` |
+| ingress.extraTls | The TLS configuration for additional hostnames to be covered with this ingress record. <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls <!-- E.g. extraTls:   - hosts:     - backstage.env.example.com     secretName: backstage-env --> | list | `[]` |
 | ingress.host | Hostname to be used to expose the route to access the backstage application (e.g: backstage.IP.nip.io) | string | `""` |
 | ingress.path | Path to be used to expose the full route to access the backstage application (e.g: IP.nip.io/backstage) | string | `"/"` |
 | ingress.tls | Ingress TLS parameters | object | `{"enabled":false,"secretName":""}` |

--- a/charts/backstage/ci/ingress-extraHosts-values.yaml
+++ b/charts/backstage/ci/ingress-extraHosts-values.yaml
@@ -1,0 +1,12 @@
+ingress:
+  enabled: true
+  host: backstage.example.com
+  tls:
+    enabled: true
+    secretName: "backstage-tls"
+  extraHosts:
+    - name: backstage.dev.example.com
+  extraTls:
+    - hosts:
+      - backstage.dev.example.com
+      secretName: "backstage-dev-tls"

--- a/charts/backstage/ci/ingress-values.yaml
+++ b/charts/backstage/ci/ingress-values.yaml
@@ -1,0 +1,6 @@
+ingress:
+  enabled: true
+  host: backstage.example.com
+  tls:
+    enabled: true
+    secretName: "backstage-tls"

--- a/charts/backstage/templates/ingress.yaml
+++ b/charts/backstage/templates/ingress.yaml
@@ -20,11 +20,16 @@ spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className | quote }}
   {{- end }}
-  {{- if .Values.ingress.tls.enabled }}
+  {{- if or .Values.ingress.tls.enabled .Values.ingress.extraTls }}
   tls:
+    {{- if .Values.ingress.tls.enabled }}
     - hosts:
       - {{ include "common.tplvalues.render" ( dict "value" .Values.ingress.host "context" $ ) }}
       secretName: {{ include "common.tplvalues.render" ( dict "value" .Values.ingress.tls.secretName "context" $ ) }}
+    {{- end }}
+    {{- if .Values.ingress.extraTls }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.extraTls "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- end }}
   rules:
     - host: {{ include "common.tplvalues.render" ( dict "value" .Values.ingress.host "context" $ ) }}
@@ -37,4 +42,16 @@ spec:
                 name: {{ include "common.names.fullname" . }}
                 port:
                   number: {{ .Values.service.ports.backend }}
+    {{- range .Values.ingress.extraHosts }}
+    - host: {{ .name | quote }}
+      http:
+        paths:
+          - path: {{ default $.Values.ingress.path .path }}
+            pathType: {{ default "Prefix" .pathType }}
+            backend:
+              service:
+                name: {{ include "common.names.fullname" $ }}
+                port:
+                  number: {{ default $.Values.service.ports.backend .port }}
+    {{- end }}
 {{- end }}

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -6124,6 +6124,52 @@
                     "title": "Enable the creation of the ingress resource",
                     "type": "boolean"
                 },
+                "extraHosts": {
+                    "default": [],
+                    "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "path": {
+                                "type": "string"
+                            },
+                            "pathType": {
+                                "type": "string"
+                            },
+                            "port": {
+                                "type": "integer"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "title": "List of additional hostnames to be covered with this ingress record",
+                    "type": "array"
+                },
+                "extraTls": {
+                    "default": [],
+                    "items": {
+                        "description": "IngressTLS describes the transport layer security associated with an ingress.",
+                        "properties": {
+                            "hosts": {
+                                "description": "hosts is a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                            },
+                            "secretName": {
+                                "description": "secretName is the name of the secret used to terminate TLS traffic on port 443. Field is left optional to allow TLS routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the \"Host\" header is used for routing.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "title": "The TLS configuration for additional hostnames to be covered with this ingress record.",
+                    "type": "array"
+                },
                 "host": {
                     "default": "",
                     "examples": [

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -143,6 +143,29 @@
                         "backstage.10.0.0.1.nip.io"
                     ]
                 },
+                "extraHosts": {
+                    "title": "List of additional hostnames to be covered with this ingress record",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "path": {
+                                "type": "string"
+                            },
+                            "pathType": {
+                                "type": "string"
+                            },
+                            "port": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                },
                 "path": {
                     "title": "Path to be used to expose the full route to access the backstage application.",
                     "type": "string",
@@ -168,6 +191,14 @@
                             "default": ""
                         }
                     }
+                },
+                "extraTls": {
+                    "title": "The TLS configuration for additional hostnames to be covered with this ingress record.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.networking.v1.IngressTLS"
+                    },
+                    "default": []
                 }
             }
         },

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -67,6 +67,15 @@ ingress:
   # -- Hostname to be used to expose the route to access the backstage application (e.g: backstage.IP.nip.io)
   host: ""
 
+  # -- List of additional hostnames to be covered with this ingress record (e.g. a CNAME)
+  # <!-- E.g.
+  # extraHosts:
+  #   - name: backstage.env.example.com
+  #     path: / (Optional)
+  #     pathType: Prefix (Optional)
+  #     port: 7007 (Optional) -->
+  extraHosts: []
+
   # -- Path to be used to expose the full route to access the backstage application (e.g: IP.nip.io/backstage)
   path: "/"
 
@@ -78,6 +87,15 @@ ingress:
 
     # -- The name to which the TLS Secret will be called
     secretName: ""
+
+  # -- The TLS configuration for additional hostnames to be covered with this ingress record.
+  # <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  # <!-- E.g.
+  # extraTls:
+  #   - hosts:
+  #     - backstage.env.example.com
+  #     secretName: backstage-env -->
+  extraTls: []
 
 # -- Backstage parameters
 # @default -- See below


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

Adds `ingress.extraHosts` and `ingress.extraTls` which allows you to add extra `host` and `tls` items to the generated Ingress resource.

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

We run Backstage in EKS and are currently adding a [condition](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations/#conditions) annotation in the Ingress to configure the AWS ALB with an extra hostname. The downside with this approach is that we have to specify the AWS ACM certificate ARN:s for the domains (we loose the certificate discovery functionality).

There are other workarounds as well (e.g. using `extraDeploy` to create multiple Ingress resources), but having native support for multiple hosts in the Helm chart would simplify our life a bit. 

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
