### PR TITLE
[WIP] chore(deps): bump bitnami-common and bitnami-postgresql versions

### DIFF
--- a/charts/backstage/Chart.lock
+++ b/charts/backstage/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.10.0
+  version: 2.26.0
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.10.0
-digest: sha256:77630aa988cef5e3a9f64a9fc3427345f451534e973dbece805850be587cb59e
-generated: "2024-05-11T14:39:32.274594+01:00"
+  version: 16.1.1
+digest: sha256:db89623dc5dbff331a4cbcb1d8f5a829a27f1d71cbc79af73cb2c89d22563438
+generated: "2024-11-04T10:35:40.574462-05:00"

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -15,11 +15,11 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     tags:
       - bitnami-common
-    version: 2.10.0
+    version: 2.26.0
   - condition: postgresql.enabled
     name: postgresql
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: 12.10.0
+    version: 16.1.1
 home: https://backstage.io
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/backstage/icon/color/backstage-icon-color.svg
 keywords:
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.0
+version: 3.1.0

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square)
+![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
@@ -105,8 +105,8 @@ Kubernetes: `>= 1.19.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://registry-1.docker.io/bitnamicharts | common | 2.10.0 |
-| oci://registry-1.docker.io/bitnamicharts | postgresql | 12.10.0 |
+| oci://registry-1.docker.io/bitnamicharts | common | 2.26.0 |
+| oci://registry-1.docker.io/bitnamicharts | postgresql | 16.1.1 |
 
 ## Values
 

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -1131,7 +1131,7 @@
                             "envFrom": {
                                 "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
                                 "items": {
-                                    "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                                    "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
                                     "properties": {
                                         "configMapRef": {
                                             "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
@@ -1148,7 +1148,7 @@
                                             "type": "object"
                                         },
                                         "prefix": {
-                                            "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                            "description": "Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.",
                                             "type": "string"
                                         },
                                         "secretRef": {
@@ -4248,7 +4248,7 @@
                             "envFrom": {
                                 "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
                                 "items": {
-                                    "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                                    "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
                                     "properties": {
                                         "configMapRef": {
                                             "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
@@ -4265,7 +4265,7 @@
                                             "type": "object"
                                         },
                                         "prefix": {
-                                            "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                            "description": "Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.",
                                             "type": "string"
                                         },
                                         "secretRef": {


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

The bitnami-common and bitnami-postgresql dependencies are pretty old and could use an update to provide expanded functionality for the Backstage Helm Chart. This update bumps both packages to their current latest versions

## Existing or Associated Issue(s)

Fixes #191

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
