### PR TITLE
feat: allow extra ports to be added to the backend service

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.0
+version: 2.3.0

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square)
+![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
@@ -125,6 +125,7 @@ Kubernetes: `>= 1.19.0-0`
 | backstage.extraEnvVars | Backstage container environment variables | list | `[]` |
 | backstage.extraEnvVarsCM | Backstage container environment variables from existing ConfigMaps | list | `[]` |
 | backstage.extraEnvVarsSecrets | Backstage container environment variables from existing Secrets | list | `[]` |
+| backstage.extraPorts | Backstage container additional ports | list | `[]` |
 | backstage.extraVolumeMounts | Backstage container additional volume mounts | list | `[]` |
 | backstage.extraVolumes | Backstage container additional volumes | list | `[]` |
 | backstage.hostAliases | Host Aliases for the pod <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/ | list | `[]` |

--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -162,6 +162,9 @@ spec:
             - name: backend
               containerPort: {{ .Values.backstage.containerPorts.backend }}
               protocol: TCP
+            {{- if .Values.backstage.extraPorts }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.extraPorts "context" $) | nindent 12 }}
+            {{- end }}
           {{- if (or .Values.backstage.extraAppConfig .Values.backstage.appConfig (and .Values.backstage.extraVolumeMounts .Values.backstage.extraVolumes)) }}
           volumeMounts:
             {{- range .Values.backstage.extraAppConfig }}

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -2389,6 +2389,42 @@
                     "title": "Backstage container environment variables from existing Secrets",
                     "type": "array"
                 },
+                "extraPorts": {
+                    "default": [],
+                    "items": {
+                        "description": "ContainerPort represents a network port in a single container.",
+                        "properties": {
+                            "containerPort": {
+                                "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                                "format": "int32",
+                                "type": "integer"
+                            },
+                            "hostIP": {
+                                "description": "What host IP to bind the external port to.",
+                                "type": "string"
+                            },
+                            "hostPort": {
+                                "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                                "format": "int32",
+                                "type": "integer"
+                            },
+                            "name": {
+                                "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                                "type": "string"
+                            },
+                            "protocol": {
+                                "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "containerPort"
+                        ],
+                        "type": "object"
+                    },
+                    "title": "Extra ports to expose in the Backstage container",
+                    "type": "array"
+                },
                 "extraVolumeMounts": {
                     "default": [],
                     "items": {

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -404,6 +404,14 @@
                         ]
                     ]
                 },
+                "extraPorts": {
+                    "title": "Extra ports to expose in the Backstage container",
+                    "type": "array",
+                    "items": {
+                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.ContainerPort"
+                    },
+                    "default": []
+                },
                 "extraVolumeMounts": {
                     "title": "Backstage container additional volume mounts",
                     "type": "array",
@@ -457,10 +465,10 @@
                     "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
                     "default": {
                         "httpGet": {
-                                "path": "/.backstage/health/v1/readiness",
-                                "port": 7007,
-                                "scheme": "HTTP"
-                            }
+                            "path": "/.backstage/health/v1/readiness",
+                            "port": 7007,
+                            "scheme": "HTTP"
+                        }
                     },
                     "examples": [
                         {
@@ -879,8 +887,12 @@
                             "description": "The port where the metrics are exposed. If using OpenTelemetry as [documented here](https://backstage.io/docs/tutorials/setup-opentelemetry/), then the port needs to be explicitely specificed. OpenTelemetry's default port is 9464.",
                             "title": "ServiceMonitor endpoint port",
                             "anyOf": [
-                                { "type": "string" },
-                                { "type": "integer" }
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
                             ]
                         }
                     }

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -158,6 +158,9 @@ backstage:
   # -- Backstage container environment variables from existing Secrets
   extraEnvVarsSecrets: []
 
+  # -- Backstage container additional ports
+  extraPorts: []
+
   # -- Backstage container additional volume mounts
   extraVolumeMounts: []
 


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

Allow chart users to specify extra backend container ports.
This is especially useful for monitoring.



## Existing or Associated Issue(s)

<!-- List any related issues. -->
This resolves #236

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
