### PR TITLE
fix: Ensure ServiceMonitor.spec.endpoints[0].port is a string

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.0
+version: 2.3.1

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square)
+![Version: 2.3.1](https://img.shields.io/badge/Version-2.3.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application

--- a/charts/backstage/templates/servicemonitor.yaml
+++ b/charts/backstage/templates/servicemonitor.yaml
@@ -29,7 +29,7 @@ spec:
     matchLabels: {{ include "common.labels.standard" . | nindent 6 }}
       app.kubernetes.io/component: backstage
   endpoints:
-  - port: {{ .Values.metrics.serviceMonitor.port }}
+  - port: {{ .Values.metrics.serviceMonitor.port | quote }}
     path: {{ .Values.metrics.serviceMonitor.path }}
     {{- with .Values.metrics.serviceMonitor.interval }}
     interval: {{ . }}


### PR DESCRIPTION
Failing to pass kubeconform checks internally

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

forces port to be a string.

before this change kubeconform failed with the following error:

```
stdin - ServiceMonitor backstage is invalid: problem validating schema. Check JSON formatting: jsonschema: '/spec/endpoints/0/port' does not validate with https://artifactory.ci.corp.tanium.com/artifactory/github/datreeio/CRDs-catalog/raw/main/monitoring.coreos.com/servicemonitor_v1.json#/properties/spec/properties/endpoints/items/properties/port/type: expected string, but got number
```

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

https://github.com/yannh/kubeconform

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
