### PR TITLE
feat: Allow configuring the Service IP Family policy to make it dual-stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Backstage unifies all your infrastructure tooling, services, and documentation t
 
 This chart focuses on providing users the same experience and functionality no matter what flavor of Kubernetes they use. This chart will support only patterns that are either customary for all Kubernetes flavors, are commonly used in the Bitnami charts ecosystem, and recognized as Backstage official patterns.
 
-We welcome other, more specialized, charts to use this cannonical chart as a direct dependency, expanding the feature set further, beyond this scope.
+We welcome other, more specialized, charts to use this canonical chart as a direct dependency, expanding the feature set further, beyond this scope.
 
 A list of derived charts:
 - OpenShift specialized chart: [Red Hat Developer Hub Helm chart](https://github.com/redhat-developer/rhdh-chart/tree/main/charts/backstage)

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.1
+version: 2.4.0

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 2.3.1](https://img.shields.io/badge/Version-2.3.1-informational?style=flat-square)
+![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
@@ -51,7 +51,7 @@ This chart bootstraps a [Backstage](https://backstage.io/docs/deployment/docker)
 
 This chart focuses on providing users the same experience and functionality no matter what flavor of Kubernetes they use. This chart will support only patterns that are either customary for all Kubernetes flavors, are commonly used in the Bitnami charts ecosystem, and recognized as Backstage official patterns.
 
-We welcome other, more specialized, charts to use this cannonical chart as a direct dependency, expanding the feature set further, beyond this scope.
+We welcome other, more specialized, charts to use this canonical chart as a direct dependency, expanding the feature set further, beyond this scope.
 
 A list of derived charts:
 - OpenShift specialized chart: [Janus Backstage Helm chart](https://github.com/janus-idp/helm-backstage/tree/main/charts/backstage)
@@ -204,6 +204,8 @@ Kubernetes: `>= 1.19.0-0`
 | service.clusterIP | Backstage service Cluster IP  <br /> E.g `clusterIP: None` | string | `""` |
 | service.externalTrafficPolicy | Backstage service external traffic policy  Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip | string | `"Cluster"` |
 | service.extraPorts | Extra ports to expose in the Backstage service (normally used with the `sidecar` value) | list | `[]` |
+| service.ipFamilies | IP Families  <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack | list | `[]` |
+| service.ipFamilyPolicy | IP Family Policy  <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack | string | `""` |
 | service.loadBalancerIP | Backstage service Load Balancer IP  <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer | string | `""` |
 | service.loadBalancerSourceRanges | Load Balancer sources  <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer <br /> E.g `loadBalancerSourceRanges: [10.10.10.0/24]` | list | `[]` |
 | service.nodePorts | Node port for the Backstage client connections Choose port between `30000-32767` | object | `{"backend":""}` |

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -45,7 +45,7 @@ This chart bootstraps a [Backstage](https://backstage.io/docs/deployment/docker)
 
 This chart focuses on providing users the same experience and functionality no matter what flavor of Kubernetes they use. This chart will support only patterns that are either customary for all Kubernetes flavors, are commonly used in the Bitnami charts ecosystem, and recognized as Backstage official patterns.
 
-We welcome other, more specialized, charts to use this cannonical chart as a direct dependency, expanding the feature set further, beyond this scope.
+We welcome other, more specialized, charts to use this canonical chart as a direct dependency, expanding the feature set further, beyond this scope.
 
 A list of derived charts:
 - OpenShift specialized chart: [Janus Backstage Helm chart](https://github.com/janus-idp/helm-backstage/tree/main/charts/backstage)

--- a/charts/backstage/ci/service-dualstack-ip-family-values.yaml
+++ b/charts/backstage/ci/service-dualstack-ip-family-values.yaml
@@ -1,0 +1,4 @@
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4

--- a/charts/backstage/templates/service.yaml
+++ b/charts/backstage/templates/service.yaml
@@ -34,6 +34,13 @@ spec:
   {{- if .Values.service.sessionAffinity }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}
   {{- end }}
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: {{ .Values.service.ports.name }}
       port: {{ .Values.service.ports.backend }}

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -7051,6 +7051,31 @@
                     "title": "Extra ports to expose in the Backstage service",
                     "type": "array"
                 },
+                "ipFamilies": {
+                    "default": [],
+                    "description": "Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services",
+                    "items": {
+                        "enum": [
+                            "IPv4",
+                            "IPv6"
+                        ],
+                        "type": "string"
+                    },
+                    "title": "Backstage service IP families",
+                    "type": "array"
+                },
+                "ipFamilyPolicy": {
+                    "default": "",
+                    "description": "Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services",
+                    "enum": [
+                        "",
+                        "SingleStack",
+                        "PreferDualStack",
+                        "RequireDualStack"
+                    ],
+                    "title": "Backstage service IP family policy",
+                    "type": "string"
+                },
                 "loadBalancerIP": {
                     "default": "",
                     "description": "Ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer",

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -730,6 +730,28 @@
                         "type": "object"
                     },
                     "default": []
+                },
+                "ipFamilyPolicy": {
+                    "title": "Backstage service IP family policy",
+                    "description": "Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services",
+                    "type": "string",
+                    "default": "",
+                    "enum": [
+                        "",
+                        "SingleStack",
+                        "PreferDualStack",
+                        "RequireDualStack"
+                    ]
+                },
+                "ipFamilies": {
+                    "title": "Backstage service IP families",
+                    "description": "Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["IPv4", "IPv6"]
+                    },
+                    "default": []
                 }
             }
         },

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -352,6 +352,16 @@ service:
   # -- Extra ports to expose in the Backstage service (normally used with the `sidecar` value)
   extraPorts: []
 
+  # -- IP Family Policy
+  #
+  # <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack
+  ipFamilyPolicy: ""
+
+  # -- IP Families
+  #
+  # <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack
+  ipFamilies: []
+
 ## @section NetworkPolicy parameters
 ##
 networkPolicy:


### PR DESCRIPTION
## Description of the change

This PR allows users to configure the `ipFamilyPolicy` and `ipFamilies` of the Kubernetes Service.
By default, Kubernetes Services are created to work only on the IPv4 stack.
People on a dual-stack network should be able to specify the policy they want.

See https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services for reference.

## Existing or Associated Issue(s)

&mdash;

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->
&mdash;

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
