### PR TITLE
Parameterizing pathType

### DIFF
--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -169,6 +169,7 @@ Kubernetes: `>= 1.19.0-0`
 | ingress.extraTls | The TLS configuration for additional hostnames to be covered with this ingress record. <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls <!-- E.g. extraTls:   - hosts:     - backstage.env.example.com     secretName: backstage-env --> | list | `[]` |
 | ingress.host | Hostname to be used to expose the route to access the backstage application (e.g: backstage.IP.nip.io) | string | `""` |
 | ingress.path | Path to be used to expose the full route to access the backstage application (e.g: IP.nip.io/backstage) | string | `"/"` |
+| ingress.pathType | Defines how the ingress path should be matched against incoming requests. Options: Prefix (matches path beginning with specified prefix), Exact (matches only exact path), or ImplementationSpecific (matching determined by ingress controller) | string | `"Prefix"` |
 | ingress.tls | Ingress TLS parameters | object | `{"enabled":false,"secretName":""}` |
 | ingress.tls.enabled | Enable TLS configuration for the host defined at `ingress.host` parameter | bool | `false` |
 | ingress.tls.secretName | The name to which the TLS Secret will be called | string | `""` |

--- a/charts/backstage/templates/ingress.yaml
+++ b/charts/backstage/templates/ingress.yaml
@@ -36,7 +36,7 @@ spec:
       http:
         paths:
           - path: {{ .Values.ingress.path }}
-            pathType: Prefix
+            pathType: {{ default "Prefix" .Values.ingress.pathType }}
             backend:
               service:
                 name: {{ include "common.names.fullname" . }}

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -79,6 +79,14 @@ ingress:
   # -- Path to be used to expose the full route to access the backstage application (e.g: IP.nip.io/backstage)
   path: "/"
 
+  # pathType defines how the ingress path should be matched against incoming requests.
+  # Options:
+  # - Prefix: Matches requests whose path begins with the specified prefix (e.g., '/app' matches '/app', '/app/resource', etc.)
+  # - Exact: Matches only the exact path specified (e.g., '/app' matches only '/app' and not '/app/resource')
+  # - ImplementationSpecific: Matching behavior is determined by the ingress controller implementation
+
+  # pathType: Prefix
+  
   # -- Ingress TLS parameters
   tls:
 


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

Introduce a configurable `pathType` for ingress, defaulting to "Prefix" if not specified.

## Existing or Associated Issue(s)

#255 

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
