### PR TITLE
[WIP] POC PR for merging `extra*` fields

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.3
+version: 2.6.0

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.6.0
+version: 2.7.0

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 2.6.0](https://img.shields.io/badge/Version-2.6.0-informational?style=flat-square)
+![Version: 2.7.0](https://img.shields.io/badge/Version-2.7.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 2.5.3](https://img.shields.io/badge/Version-2.5.3-informational?style=flat-square)
+![Version: 2.6.0](https://img.shields.io/badge/Version-2.6.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application

--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -156,7 +156,15 @@ spec:
                   key: {{ include "backstage.postgresql.databaseSecretKey" . }}
             {{- end }}
             {{- if .Values.backstage.extraEnvVars }}
+            {{- if (kindIs "map" .Values.backstage.extraEnvVars) }}
+            {{- /* If extraEnvVars is a dict, Helm will merge it automatically by key */ -}}
+            {{- range $_, $value := .Values.backstage.extraEnvVars }}
+            - {{- include "common.tplvalues.render" ( dict "value" $value "context" $) | nindent 14 }}
+            {{- end }}
+            {{- else if (kindIs "slice" .Values.backstage.extraEnvVars) }}
+            {{- /* If extraEnvVars is a list, keep current behavior (no merging) */ -}}
             {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
             {{- end }}
           ports:
             - name: backend

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -2240,130 +2240,258 @@
                     "type": "array"
                 },
                 "extraEnvVars": {
-                    "default": [],
-                    "examples": [
-                        [
-                            {
-                                "name": "APP_CONFIG_backend_cache_store",
-                                "value": "memory"
-                            }
-                        ]
-                    ],
-                    "items": {
-                        "description": "EnvVar represents an environment variable present in a Container.",
-                        "properties": {
-                            "name": {
-                                "description": "Name of the environment variable. May consist of any printable ASCII characters except '='.",
-                                "type": "string"
-                            },
-                            "value": {
-                                "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
-                                "type": "string"
-                            },
-                            "valueFrom": {
-                                "description": "EnvVarSource represents a source for the value of an EnvVar.",
+                    "oneOf": [
+                        {
+                            "default": [],
+                            "examples": [
+                                [
+                                    {
+                                        "name": "APP_CONFIG_backend_cache_store",
+                                        "value": "memory"
+                                    }
+                                ]
+                            ],
+                            "items": {
+                                "description": "EnvVar represents an environment variable present in a Container.",
                                 "properties": {
-                                    "configMapKeyRef": {
-                                        "description": "Selects a key from a ConfigMap.",
-                                        "properties": {
-                                            "key": {
-                                                "description": "The key to select.",
-                                                "type": "string"
-                                            },
-                                            "name": {
-                                                "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                                "type": "string"
-                                            },
-                                            "optional": {
-                                                "description": "Specify whether the ConfigMap or its key must be defined",
-                                                "type": "boolean"
-                                            }
-                                        },
-                                        "required": [
-                                            "key"
-                                        ],
-                                        "type": "object",
-                                        "x-kubernetes-map-type": "atomic"
+                                    "name": {
+                                        "description": "Name of the environment variable. May consist of any printable ASCII characters except '='.",
+                                        "type": "string"
                                     },
-                                    "fieldRef": {
-                                        "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
-                                        "properties": {
-                                            "apiVersion": {
-                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
-                                                "type": "string"
-                                            },
-                                            "fieldPath": {
-                                                "description": "Path of the field to select in the specified API version.",
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "fieldPath"
-                                        ],
-                                        "type": "object",
-                                        "x-kubernetes-map-type": "atomic"
+                                    "value": {
+                                        "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                        "type": "string"
                                     },
-                                    "resourceFieldRef": {
-                                        "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+                                    "valueFrom": {
+                                        "description": "EnvVarSource represents a source for the value of an EnvVar.",
                                         "properties": {
-                                            "containerName": {
-                                                "description": "Container name: required for volumes, optional for env vars",
-                                                "type": "string"
-                                            },
-                                            "divisor": {
-                                                "oneOf": [
-                                                    {
+                                            "configMapKeyRef": {
+                                                "description": "Selects a key from a ConfigMap.",
+                                                "properties": {
+                                                    "key": {
+                                                        "description": "The key to select.",
                                                         "type": "string"
                                                     },
-                                                    {
-                                                        "type": "number"
+                                                    "name": {
+                                                        "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                        "type": "string"
+                                                    },
+                                                    "optional": {
+                                                        "description": "Specify whether the ConfigMap or its key must be defined",
+                                                        "type": "boolean"
                                                     }
-                                                ]
+                                                },
+                                                "required": [
+                                                    "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic"
                                             },
-                                            "resource": {
-                                                "description": "Required: resource to select",
-                                                "type": "string"
+                                            "fieldRef": {
+                                                "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+                                                "properties": {
+                                                    "apiVersion": {
+                                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                        "type": "string"
+                                                    },
+                                                    "fieldPath": {
+                                                        "description": "Path of the field to select in the specified API version.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "fieldPath"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "resourceFieldRef": {
+                                                "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+                                                "properties": {
+                                                    "containerName": {
+                                                        "description": "Container name: required for volumes, optional for env vars",
+                                                        "type": "string"
+                                                    },
+                                                    "divisor": {
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "number"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "resource": {
+                                                        "description": "Required: resource to select",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "resource"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "secretKeyRef": {
+                                                "description": "SecretKeySelector selects a key of a Secret.",
+                                                "properties": {
+                                                    "key": {
+                                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                        "type": "string"
+                                                    },
+                                                    "optional": {
+                                                        "description": "Specify whether the Secret or its key must be defined",
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic"
                                             }
                                         },
-                                        "required": [
-                                            "resource"
-                                        ],
-                                        "type": "object",
-                                        "x-kubernetes-map-type": "atomic"
-                                    },
-                                    "secretKeyRef": {
-                                        "description": "SecretKeySelector selects a key of a Secret.",
-                                        "properties": {
-                                            "key": {
-                                                "description": "The key of the secret to select from.  Must be a valid secret key.",
-                                                "type": "string"
-                                            },
-                                            "name": {
-                                                "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                                "type": "string"
-                                            },
-                                            "optional": {
-                                                "description": "Specify whether the Secret or its key must be defined",
-                                                "type": "boolean"
-                                            }
-                                        },
-                                        "required": [
-                                            "key"
-                                        ],
-                                        "type": "object",
-                                        "x-kubernetes-map-type": "atomic"
+                                        "type": "object"
                                     }
                                 },
+                                "required": [
+                                    "name"
+                                ],
                                 "type": "object"
-                            }
+                            },
+                            "type": "array"
                         },
-                        "required": [
-                            "name"
-                        ],
-                        "type": "object"
-                    },
-                    "title": "Backstage container environment variables",
-                    "type": "array"
+                        {
+                            "additionalProperties": {
+                                "description": "EnvVar represents an environment variable present in a Container.",
+                                "properties": {
+                                    "name": {
+                                        "description": "Name of the environment variable. May consist of any printable ASCII characters except '='.",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                        "type": "string"
+                                    },
+                                    "valueFrom": {
+                                        "description": "EnvVarSource represents a source for the value of an EnvVar.",
+                                        "properties": {
+                                            "configMapKeyRef": {
+                                                "description": "Selects a key from a ConfigMap.",
+                                                "properties": {
+                                                    "key": {
+                                                        "description": "The key to select.",
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                        "type": "string"
+                                                    },
+                                                    "optional": {
+                                                        "description": "Specify whether the ConfigMap or its key must be defined",
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "fieldRef": {
+                                                "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+                                                "properties": {
+                                                    "apiVersion": {
+                                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                        "type": "string"
+                                                    },
+                                                    "fieldPath": {
+                                                        "description": "Path of the field to select in the specified API version.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "fieldPath"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "resourceFieldRef": {
+                                                "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+                                                "properties": {
+                                                    "containerName": {
+                                                        "description": "Container name: required for volumes, optional for env vars",
+                                                        "type": "string"
+                                                    },
+                                                    "divisor": {
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "number"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "resource": {
+                                                        "description": "Required: resource to select",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "resource"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "secretKeyRef": {
+                                                "description": "SecretKeySelector selects a key of a Secret.",
+                                                "properties": {
+                                                    "key": {
+                                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                        "type": "string"
+                                                    },
+                                                    "optional": {
+                                                        "description": "Specify whether the Secret or its key must be defined",
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "key"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                },
+                                "required": [
+                                    "name"
+                                ],
+                                "type": "object"
+                            },
+                            "examples": [
+                                {
+                                    "APP_CONFIG_backend_cache_store": {
+                                        "name": "APP_CONFIG_backend_cache_store",
+                                        "value": "memory"
+                                    }
+                                }
+                            ],
+                            "type": "object"
+                        }
+                    ],
+                    "title": "Backstage container environment variables"
                 },
                 "extraEnvVarsCM": {
                     "default": [],
@@ -3293,7 +3421,7 @@
                                 "description": "Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.",
                                 "properties": {
                                     "endpoints": {
-                                        "description": "endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                        "description": "endpoints is the endpoint name that details Glusterfs topology.",
                                         "type": "string"
                                     },
                                     "path": {

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -391,18 +391,37 @@
                 },
                 "extraEnvVars": {
                     "title": "Backstage container environment variables",
-                    "type": "array",
-                    "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar"
-                    },
-                    "default": [],
-                    "examples": [
-                        [
-                            {
-                                "name": "APP_CONFIG_backend_cache_store",
-                                "value": "memory"
-                            }
-                        ]
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar"
+                            },
+                            "default": [],
+                            "examples": [
+                                [
+                                    {
+                                        "name": "APP_CONFIG_backend_cache_store",
+                                        "value": "memory"
+                                    }
+                                ]
+                            ]
+                        },
+                        {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "object",
+                                "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar"
+                            },
+                            "examples": [
+                                {
+                                    "APP_CONFIG_backend_cache_store": {
+                                        "name": "APP_CONFIG_backend_cache_store",
+                                        "value": "memory"
+                                    }
+                                }
+                            ]
+                        }
                     ]
                 },
                 "extraEnvVarsCM": {


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves backstage/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

This is a draft POC PR to illustrate the proposal in #269

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

Fixes #269 

## Additional Information

- [This branch](https://github.com/rm3l/rhdh-chart/tree/rhidp-6082-spike-helm-investigate-how-to-support-merging-of-extra-fields-from-the-upstream-backstage-chart--poc-merge-key/charts/backstage) in our derived chart illustrates how we would define these extra env vars as a map in the [default values.yaml file](https://github.com/rm3l/rhdh-chart/blob/rhidp-6082-spike-helm-investigate-how-to-support-merging-of-extra-fields-from-the-upstream-backstage-chart--poc-merge-key/charts/backstage/values.yaml#L126-L138), so that users can easily provide their [own values.yaml extending these env vars](https://github.com/rm3l/rhdh-chart/blob/rhidp-6082-spike-helm-investigate-how-to-support-merging-of-extra-fields-from-the-upstream-backstage-chart--poc-merge-key/charts/backstage/ci/test-merge-extraEnvVars-values.yaml#L3-L12).
When using the changes here against this branch, the Deployment rendered contains the expected extra env vars merged from both values.yaml:

<details>
<summary>helm template</summary>

```
$ helm template charts/backstage --values charts/backstage/ci/test-merge-extraEnvVars-values.yaml
```

```yaml
---
[...]
---
# Source: backstage/charts/upstream/templates/backstage-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-developer-hub
  namespace: "my-ns"
  labels: 
    app.kubernetes.io/name: developer-hub
    helm.sh/chart: upstream-2.5.3
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: backstage
  annotations:
spec:
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app.kubernetes.io/name: developer-hub
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/component: backstage
  template:
    metadata:
      labels:
        app.kubernetes.io/name: developer-hub
        helm.sh/chart: upstream-2.5.3
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/component: backstage
      annotations:
        checksum/app-config: a51552987cdb96e1fb3edccca2150e003a888839c9ff5894826e4771b17fdd3c
        checksum/dynamic-plugins: 'f1f9a92f14a31362d7eb30e67ac1458faf1c685765610f93a8967194d8bc1a5f'
    spec:
      serviceAccountName: default
      volumes:
        - ephemeral:
            volumeClaimTemplate:
              spec:
                accessModes:
                - ReadWriteOnce
                resources:
                  requests:
                    storage: 5Gi
          name: dynamic-plugins-root
        - configMap:
            defaultMode: 420
            name: 'release-name-dynamic-plugins'
            optional: true
          name: dynamic-plugins
        - name: dynamic-plugins-npmrc
          secret:
            defaultMode: 420
            optional: true
            secretName: 'release-name-dynamic-plugins-npmrc'
        - name: dynamic-plugins-registry-auth
          secret:
            defaultMode: 416
            optional: true
            secretName: 'release-name-dynamic-plugins-registry-auth'
        - emptyDir: {}
          name: npmcacache
        - emptyDir: {}
          name: temp
        - name: backstage-app-config
          configMap:
            name: release-name-developer-hub-app-config
      
      initContainers:
        - command:
          - ./install-dynamic-plugins.sh
          - /dynamic-plugins-root
          env:
          - name: NPM_CONFIG_USERCONFIG
            value: /opt/app-root/src/.npmrc.dynamic-plugins
          - name: MAX_ENTRY_SIZE
            value: "30000000"
          image: 'quay.io/rhdh/rhdh-hub-rhel9:latest'
          imagePullPolicy: Always
          name: install-dynamic-plugins
          resources:
            limits:
              cpu: 1000m
              ephemeral-storage: 5Gi
              memory: 2.5Gi
            requests:
              cpu: 250m
              memory: 256Mi
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            seccompProfile:
              type: RuntimeDefault
          volumeMounts:
          - mountPath: /dynamic-plugins-root
            name: dynamic-plugins-root
          - mountPath: /opt/app-root/src/dynamic-plugins.yaml
            name: dynamic-plugins
            readOnly: true
            subPath: dynamic-plugins.yaml
          - mountPath: /opt/app-root/src/.npmrc.dynamic-plugins
            name: dynamic-plugins-npmrc
            readOnly: true
            subPath: .npmrc
          - mountPath: /opt/app-root/src/.config/containers
            name: dynamic-plugins-registry-auth
            readOnly: true
          - mountPath: /opt/app-root/src/.npm/_cacache
            name: npmcacache
          - mountPath: /tmp
            name: temp
          workingDir: /opt/app-root/src
      containers:
        - name: backstage-backend
          image: quay.io/rhdh/rhdh-hub-rhel9:latest
          imagePullPolicy: "Always"
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            seccompProfile:
              type: RuntimeDefault
          args:
            - "--config"
            - "dynamic-plugins-root/app-config.dynamic-plugins.yaml"
            - "--config"
            - "/opt/app-root/src/app-config-from-configmap.yaml"
          resources:
            limits:
              cpu: 1000m
              ephemeral-storage: 5Gi
              memory: 2.5Gi
            requests:
              cpu: 250m
              memory: 1Gi
          readinessProbe:
            failureThreshold: 3
            httpGet:
              path: /.backstage/health/v1/readiness
              port: backend
              scheme: HTTP
            periodSeconds: 10
            successThreshold: 2
            timeoutSeconds: 4
          livenessProbe:
            failureThreshold: 3
            httpGet:
              path: /.backstage/health/v1/liveness
              port: backend
              scheme: HTTP
            periodSeconds: 10
            successThreshold: 1
            timeoutSeconds: 4
          startupProbe:
            failureThreshold: 3
            httpGet:
              path: /.backstage/health/v1/liveness
              port: backend
              scheme: HTTP
            initialDelaySeconds: 30
            periodSeconds: 20
            successThreshold: 1
            timeoutSeconds: 4
          env:
            - name: APP_CONFIG_backend_listen_port
              value: "7007"
            - name: POSTGRES_HOST
              value: release-name-postgresql
            - name: POSTGRES_PORT
              value: "5432"
            - name: POSTGRES_USER
              value: bn_backstage
            - name: POSTGRES_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: release-name-postgresql
                  key: password
            -
              name: BACKEND_SECRET
              valueFrom:
                secretKeyRef:
                  key: backend-secret
                  name: 'release-name-auth'
            -
              name: HTTP_PROXY
              valueFrom:
                secretKeyRef:
                  key: http-proxy
                  name: my-super-secret
            -
              name: POSTGRESQL_ADMIN_PASSWORD
              valueFrom:
                secretKeyRef:
                  key: postgres-password
                  name: 'release-name-postgresql'
            -
              name: LOG_LEVEL
              value: debug
          ports:
            - name: backend
              containerPort: 7007
              protocol: TCP
          volumeMounts:
            - name: backstage-app-config
              mountPath: "/opt/app-root/src/app-config-from-configmap.yaml"
              subPath: app-config.yaml
            - mountPath: /opt/app-root/src/dynamic-plugins-root
              name: dynamic-plugins-root
            - mountPath: /tmp
              name: temp
---
[...]
```

</details>


- [This other branch](https://github.com/rm3l/rhdh-chart/blob/rhidp-6082-spike-helm-investigate-how-to-support-merging-of-extra-fields-from-the-upstream-backstage-chart--poc-merge-key-compat/charts/backstage/values.yaml#L126-L136) illustrates how the changes here remain 100% backward compatible when `extraEnvVars` is an array. See the [test values file](https://github.com/rm3l/rhdh-chart/blob/rhidp-6082-spike-helm-investigate-how-to-support-merging-of-extra-fields-from-the-upstream-backstage-chart--poc-merge-key-compat/charts/backstage/ci/test-merge-extraEnvVars-compat-values.yaml) highlighting the current behavior where we need to replicate all the chart default elements.

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
