### PR TITLE
Davivcgarcia bitnami fix

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.6.1
+version: 2.6.2

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -423,6 +423,11 @@ postgresql:
   # -- Switch to enable or disable the PostgreSQL helm chart
   enabled: false
 
+  # -- Change default PostgreSQL image location (workaround for https://github.com/bitnami/charts/issues/35164)
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
+
   # -- The authentication details of the Postgres database
   auth:
 


### PR DESCRIPTION
## Description of the change

Provides the fix for the recent Bitnami migration of public images to Bitnami Legacy. The usage of Bitnami Secure is risky since the only tag available is latest, and the current PostgreSQL chart uses a specific version tag.

## Existing or Associated Issue(s)

Temporary Fix for #271

## Additional Information

https://github.com/bitnami/charts/issues/35164

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
