### PR TITLE
feat: allow configuring the Deployment update strategy

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.6.3
+version: 2.7.0

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 2.6.3](https://img.shields.io/badge/Version-2.6.3-informational?style=flat-square)
+![Version: 2.7.0](https://img.shields.io/badge/Version-2.7.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
@@ -149,6 +149,7 @@ Kubernetes: `>= 1.19.0-0`
 | backstage.resources | Resource requests/limits <br /> Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container <!-- E.g. resources:   limits:     memory: 1Gi     cpu: 1000m   requests:     memory: 250Mi     cpu: 100m --> | object | `{}` |
 | backstage.revisionHistoryLimit | Define the [count of deployment revisions](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) to be kept. May be set to 0 in case of GitOps deployment approach. | int | `10` |
 | backstage.startupProbe | Startup Probe Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes <!-- E.g. startupProbe:   failureThreshold: 3   httpGet:     path: /.backstage/health/v1/liveness     port: 7007     scheme: HTTP   initialDelaySeconds: 60   periodSeconds: 10   successThreshold: 1   timeoutSeconds: 2 | object | `{"httpGet":{"path":"/.backstage/health/v1/liveness","port":7007,"scheme":"HTTP"}}` |
+| backstage.strategy | Deployment [update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy). When unset, Kubernetes applies its default (RollingUpdate with maxSurge 25% and maxUnavailable 25%). Set to `Recreate` (or `RollingUpdate` with `maxSurge: 0`) to guarantee a single Backstage pod runs at a time, which is recommended when plugin database migrations run on startup to avoid concurrent migration attempts. <!-- E.g. strategy:   type: RollingUpdate   rollingUpdate:     maxSurge: 0     maxUnavailable: 1 --> | object | `{}` |
 | backstage.tolerations | Node tolerations for server scheduling to nodes with taints <br /> Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ | list | `[]` |
 | backstage.topologySpreadConstraints | Topology Spread Constraints for pod assignment <br /> Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#pod-topology-spread-constraints | list | `[]` |
 | clusterDomain | Default Kubernetes cluster domain | string | `"cluster.local"` |

--- a/charts/backstage/ci/strategy-values.yaml
+++ b/charts/backstage/ci/strategy-values.yaml
@@ -1,0 +1,6 @@
+backstage:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1

--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -24,6 +24,9 @@ spec:
   replicas: {{ .Values.backstage.replicas }}
   {{- end }}
   revisionHistoryLimit: {{ .Values.backstage.revisionHistoryLimit }}
+  {{- if .Values.backstage.strategy }}
+  strategy: {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.strategy "context" $) | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: backstage

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -6111,6 +6111,24 @@
                     },
                     "type": "object"
                 },
+                "strategy": {
+                    "default": {},
+                    "description": "Kubernetes Deployment strategy (RollingUpdate or Recreate). Leave empty to use the Kubernetes default (RollingUpdate with maxSurge 25% and maxUnavailable 25%).",
+                    "examples": [
+                        {
+                            "type": "Recreate"
+                        },
+                        {
+                            "rollingUpdate": {
+                                "maxSurge": 0,
+                                "maxUnavailable": 1
+                            },
+                            "type": "RollingUpdate"
+                        }
+                    ],
+                    "title": "Deployment update strategy",
+                    "type": "object"
+                },
                 "tolerations": {
                     "default": [],
                     "description": "Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/",

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -219,6 +219,24 @@
                     "minimum": 0,
                     "default": 10
                 },
+                "strategy": {
+                    "title": "Deployment update strategy",
+                    "description": "Kubernetes Deployment strategy (RollingUpdate or Recreate). Leave empty to use the Kubernetes default (RollingUpdate with maxSurge 25% and maxUnavailable 25%).",
+                    "type": "object",
+                    "default": {},
+                    "examples": [
+                        {
+                            "type": "Recreate"
+                        },
+                        {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0,
+                                "maxUnavailable": 1
+                            }
+                        }
+                    ]
+                },
                 "image": {
                     "title": "Image parameters",
                     "type": "object",

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -108,6 +108,17 @@ backstage:
   # May be set to 0 in case of GitOps deployment approach.
   revisionHistoryLimit: 10
 
+  # -- Deployment [update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy).
+  # When unset, Kubernetes applies its default (RollingUpdate with maxSurge 25% and maxUnavailable 25%).
+  # Set to `Recreate` (or `RollingUpdate` with `maxSurge: 0`) to guarantee a single Backstage pod runs at a time, which is recommended when plugin database migrations run on startup to avoid concurrent migration attempts.
+  # <!-- E.g.
+  # strategy:
+  #   type: RollingUpdate
+  #   rollingUpdate:
+  #     maxSurge: 0
+  #     maxUnavailable: 1 -->
+  strategy: {}
+
   image:
 
     # -- Backstage image registry


### PR DESCRIPTION
## Summary

Adds a new `backstage.strategy` value that maps to the Deployment `spec.strategy` field so operators can opt into `Recreate` (or `RollingUpdate` with `maxSurge: 0`) and guarantee that only one Backstage pod runs at a time.

Default behavior is unchanged: when `backstage.strategy` is unset (the default `{}`), no strategy block is rendered and Kubernetes keeps applying its own default (`RollingUpdate` with `maxSurge: 25%` / `maxUnavailable: 25%`).

## Motivation

Backstage plugins (e.g. `catalog`, `auth`) run knex database migrations during plugin initialization on every pod startup. Under the current default `RollingUpdate` strategy, a new pod starts while the old pod is still running, and both race the `knex_migrations_lock` row. If either pod is killed mid-migration (OOM, node drain, probe failure during the rollout), the lock stays set (`is_locked = 1`) and every subsequent pod fails catalog startup with:

```
MigrationLocked: Migration table is already locked
If you are sure migrations are not running you can release the lock manually
by running 'knex migrate:unlock'
```

Recovery requires manual DB intervention — not great on production.

Allowing operators to pin the strategy to `Recreate` (or `RollingUpdate` with `maxSurge: 0`) removes the concurrent-migration race entirely for single-replica deployments (which is the common case for Backstage).

## Usage

```yaml
backstage:
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxSurge: 0
      maxUnavailable: 1
```

or

```yaml
backstage:
  strategy:
    type: Recreate
```

## Changes

- `values.yaml`: add `backstage.strategy` (default `{}`) with helm-docs comment.
- `values.schema.tmpl.json`: add JSON schema entry with examples; `values.schema.json` regenerated by the `jsonschema-dereference` pre-commit hook.
- `templates/backstage-deployment.yaml`: conditionally render `spec.strategy` from `.Values.backstage.strategy` using `common.tplvalues.render` so templated values (e.g. global settings) are supported.
- `ci/strategy-values.yaml`: new CI test case (`RollingUpdate` with `maxSurge: 0`).
- `Chart.yaml`: bump chart version `2.6.3` → `2.7.0` (minor — new additive feature, backward-compatible).
- `README.md`: regenerated by `helm-docs`.

## Test plan

- [x] `pre-commit run --all-files` passes (helm-docs, jsonschema-dereference, codespell).
- [x] `ct lint --charts charts/backstage` passes against all `ci/*-values.yaml` files including the new `strategy-values.yaml`.
- [x] `helm template` with default values produces **no** `strategy` block in the rendered Deployment (preserves existing behavior).
- [x] `helm template` with `ci/strategy-values.yaml` correctly renders the `strategy` block with `maxSurge: 0`, `maxUnavailable: 1`.
- [x] Commit is GPG-signed and DCO signed-off per `CONTRIBUTING.md`.