### PR TITLE
feat: integrate gateway api endpoint for chart deployment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,10 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # pin@v1.14.0
 
+      - name: Install Gateway API CRDs
+        if: steps.list-changed.outputs.changed == 'true'
+        run: kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.0/standard-install.yaml
+
       - name: Install Ingress Controller
         if: steps.list-changed.outputs.changed == 'true'
         run: "helm install ingress-nginx/ingress-nginx --generate-name --set controller.service.type='NodePort' --set controller.admissionWebhooks.enabled=false"

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.7.0
+version: 2.8.0

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 2.7.0](https://img.shields.io/badge/Version-2.7.0-informational?style=flat-square)
+![Version: 2.8.0](https://img.shields.io/badge/Version-2.8.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
@@ -164,6 +164,13 @@ Kubernetes: `>= 1.19.0-0`
 | global | Global parameters Global Docker image parameters Please, note that this will override the image parameters, including dependencies, configured to use the global value Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass | object | See below |
 | global.imagePullSecrets | Global Docker registry secret names as an array </br> E.g. `imagePullSecrets: [myRegistryKeySecretName]` | list | `[]` |
 | global.imageRegistry | Global Docker image registry | string | `""` |
+| httpRoute | HTTPRoute parameters | object | `{"annotations":{},"enabled":false,"hostnames":[],"labels":{},"parentRefs":[],"rules":[{"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]}` |
+| httpRoute.annotations | Additional annotations for the HTTPRoute resource | object | `{}` |
+| httpRoute.enabled | Enable the creation of the HTTPRoute resource | bool | `false` |
+| httpRoute.hostnames | List of hostnames matching HTTP header | list | `[]` |
+| httpRoute.labels | Additional labels for the HTTPRoute resource | object | `{}` |
+| httpRoute.parentRefs | List of Gateways this HTTPRoute is attached to | list | `[]` |
+| httpRoute.rules | List of rules and filters applied to the HTTPRoute | list | `[{"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` |
 | ingress | Ingress parameters | object | `{"annotations":{},"className":"","enabled":false,"extraHosts":[],"extraTls":[],"host":"","path":"/","tls":{"enabled":false,"secretName":""}}` |
 | ingress.annotations | Additional annotations for the Ingress resource | object | `{}` |
 | ingress.className | Name of the IngressClass cluster resource which defines which controller will implement the resource (e.g nginx) | string | `""` |

--- a/charts/backstage/ci/httproute-values.yaml
+++ b/charts/backstage/ci/httproute-values.yaml
@@ -1,0 +1,7 @@
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: default
+      namespace: proxy
+  hostnames:
+    - backstage.example.com

--- a/charts/backstage/ci/httproute-values.yaml
+++ b/charts/backstage/ci/httproute-values.yaml
@@ -5,3 +5,10 @@ httpRoute:
       namespace: proxy
   hostnames:
     - backstage.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      timeouts:
+        request: 10s

--- a/charts/backstage/templates/httproute.yaml
+++ b/charts/backstage/templates/httproute.yaml
@@ -34,11 +34,15 @@ spec:
     {{- range .Values.httpRoute.rules }}
     {{- with .matches }}
     - matches:
-      {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .filters }}
       filters:
-      {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- if .name }}
       name: {{ .name }}

--- a/charts/backstage/templates/httproute.yaml
+++ b/charts/backstage/templates/httproute.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "common.names.fullname" . -}}
+{{- $svcPort := .Values.service.ports.backend -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: backstage
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.httpRoute.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.httpRoute.labels "context" $) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.httpRoute.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.httpRoute.annotations "context" $) | nindent 4 }}
+    {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.httpRoute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- if .name }}
+      name: {{ .name }}
+    {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -6358,6 +6358,223 @@
             "title": "Global parameters.",
             "type": "object"
         },
+        "httpRoute": {
+            "additionalProperties": false,
+            "properties": {
+                "annotations": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {},
+                    "title": "Additional annotations for the HTTPRoute resource",
+                    "type": "object"
+                },
+                "enabled": {
+                    "default": false,
+                    "title": "Enable the creation of the HTTPRoute resource",
+                    "type": "boolean"
+                },
+                "hostnames": {
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "List of hostnames matching HTTP header",
+                    "type": "array"
+                },
+                "labels": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {},
+                    "title": "Additional labels for the HTTPRoute resource",
+                    "type": "object"
+                },
+                "parentRefs": {
+                    "default": [],
+                    "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "group": {
+                                "title": "Group is the group of the referent.",
+                                "type": "string"
+                            },
+                            "kind": {
+                                "title": "Kind is kind of the referent.",
+                                "type": "string"
+                            },
+                            "name": {
+                                "title": "Name is the name of the referent.",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "title": "Namespace is the namespace of the referent.",
+                                "type": "string"
+                            },
+                            "port": {
+                                "title": "Port is the network port this Route targets.",
+                                "type": "integer"
+                            },
+                            "sectionName": {
+                                "title": "SectionName is the name of a section within the target resource.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name"
+                        ],
+                        "type": "object"
+                    },
+                    "title": "List of Gateways this HTTPRoute is attached to",
+                    "type": "array"
+                },
+                "rules": {
+                    "default": [],
+                    "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "backendRefs": {
+                                "items": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "group": {
+                                            "type": "string"
+                                        },
+                                        "kind": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "namespace": {
+                                            "type": "string"
+                                        },
+                                        "port": {
+                                            "type": "integer"
+                                        },
+                                        "weight": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
+                            "filters": {
+                                "items": {
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
+                            "matches": {
+                                "items": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "headers": {
+                                            "items": {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": {
+                                                        "enum": [
+                                                            "Exact",
+                                                            "RegularExpression"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "value"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "method": {
+                                            "enum": [
+                                                "GET",
+                                                "HEAD",
+                                                "POST",
+                                                "PUT",
+                                                "DELETE",
+                                                "CONNECT",
+                                                "OPTIONS",
+                                                "TRACE",
+                                                "PATCH"
+                                            ],
+                                            "type": "string"
+                                        },
+                                        "path": {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "type": {
+                                                    "enum": [
+                                                        "Exact",
+                                                        "PathPrefix",
+                                                        "RegularExpression"
+                                                    ],
+                                                    "title": "HTTPPathMatchType specifies the semantics of how HTTP paths should be compared.",
+                                                    "type": "string"
+                                                },
+                                                "value": {
+                                                    "title": "Value of the HTTP path to match against.",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "title": "Path specifies a HTTP request path matcher.",
+                                            "type": "object"
+                                        },
+                                        "queryParams": {
+                                            "items": {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": {
+                                                        "enum": [
+                                                            "Exact",
+                                                            "RegularExpression"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "value"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
+                            "name": {
+                                "title": "Name is the name of the rule.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "title": "List of rules and filters applied to the HTTPRoute",
+                    "type": "array"
+                }
+            },
+            "title": "HTTPRoute parameters",
+            "type": "object"
+        },
         "ingress": {
             "additionalProperties": false,
             "properties": {

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -6564,6 +6564,21 @@
                             "name": {
                                 "title": "Name is the name of the rule.",
                                 "type": "string"
+                            },
+                            "timeouts": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "backendRequest": {
+                                        "title": "BackendRequest specifies a timeout for an individual request from the gateway to a backend.",
+                                        "type": "string"
+                                    },
+                                    "request": {
+                                        "title": "Request specifies the maximum duration for a gateway to respond to an HTTP request.",
+                                        "type": "string"
+                                    }
+                                },
+                                "title": "Timeouts defines the timeouts that can be configured for an HTTP request.",
+                                "type": "object"
                             }
                         },
                         "type": "object"

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -109,6 +109,223 @@
                 }
             }
         },
+        "httpRoute": {
+            "additionalProperties": false,
+            "properties": {
+                "annotations": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {},
+                    "title": "Additional annotations for the HTTPRoute resource",
+                    "type": "object"
+                },
+                "enabled": {
+                    "default": false,
+                    "title": "Enable the creation of the HTTPRoute resource",
+                    "type": "boolean"
+                },
+                "hostnames": {
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "List of hostnames matching HTTP header",
+                    "type": "array"
+                },
+                "labels": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {},
+                    "title": "Additional labels for the HTTPRoute resource",
+                    "type": "object"
+                },
+                "parentRefs": {
+                    "default": [],
+                    "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "group": {
+                                "title": "Group is the group of the referent.",
+                                "type": "string"
+                            },
+                            "kind": {
+                                "title": "Kind is kind of the referent.",
+                                "type": "string"
+                            },
+                            "name": {
+                                "title": "Name is the name of the referent.",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "title": "Namespace is the namespace of the referent.",
+                                "type": "string"
+                            },
+                            "port": {
+                                "title": "Port is the network port this Route targets.",
+                                "type": "integer"
+                            },
+                            "sectionName": {
+                                "title": "SectionName is the name of a section within the target resource.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name"
+                        ],
+                        "type": "object"
+                    },
+                    "title": "List of Gateways this HTTPRoute is attached to",
+                    "type": "array"
+                },
+                "rules": {
+                    "default": [],
+                    "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "name": {
+                                "title": "Name is the name of the rule.",
+                                "type": "string"
+                            },
+                            "backendRefs": {
+                                "items": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "group": {
+                                            "type": "string"
+                                        },
+                                        "kind": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "namespace": {
+                                            "type": "string"
+                                        },
+                                        "port": {
+                                            "type": "integer"
+                                        },
+                                        "weight": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
+                            "filters": {
+                                "items": {
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
+                            "matches": {
+                                "items": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "headers": {
+                                            "items": {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": {
+                                                        "enum": [
+                                                            "Exact",
+                                                            "RegularExpression"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "value"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "method": {
+                                            "enum": [
+                                                "GET",
+                                                "HEAD",
+                                                "POST",
+                                                "PUT",
+                                                "DELETE",
+                                                "CONNECT",
+                                                "OPTIONS",
+                                                "TRACE",
+                                                "PATCH"
+                                            ],
+                                            "type": "string"
+                                        },
+                                        "path": {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "type": {
+                                                    "enum": [
+                                                        "Exact",
+                                                        "PathPrefix",
+                                                        "RegularExpression"
+                                                    ],
+                                                    "title": "HTTPPathMatchType specifies the semantics of how HTTP paths should be compared.",
+                                                    "type": "string"
+                                                },
+                                                "value": {
+                                                    "title": "Value of the HTTP path to match against.",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "title": "Path specifies a HTTP request path matcher.",
+                                            "type": "object"
+                                        },
+                                        "queryParams": {
+                                            "items": {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": {
+                                                        "enum": [
+                                                            "Exact",
+                                                            "RegularExpression"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "value"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "title": "List of rules and filters applied to the HTTPRoute",
+                    "type": "array"
+                }
+            },
+            "title": "HTTPRoute parameters",
+            "type": "object"
+        },
         "ingress": {
             "title": "Ingress parameters",
             "type": "object",

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -315,6 +315,21 @@
                                     "type": "object"
                                 },
                                 "type": "array"
+                            },
+                            "timeouts": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "backendRequest": {
+                                        "title": "BackendRequest specifies a timeout for an individual request from the gateway to a backend.",
+                                        "type": "string"
+                                    },
+                                    "request": {
+                                        "title": "Request specifies the maximum duration for a gateway to respond to an HTTP request.",
+                                        "type": "string"
+                                    }
+                                },
+                                "title": "Timeouts defines the timeouts that can be configured for an HTTP request.",
+                                "type": "object"
                             }
                         },
                         "type": "object"

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -97,6 +97,31 @@ ingress:
   #     secretName: backstage-env -->
   extraTls: []
 
+# -- HTTPRoute parameters
+httpRoute:
+
+  # -- Enable the creation of the HTTPRoute resource
+  enabled: false
+
+  # -- Additional labels for the HTTPRoute resource
+  labels: {}
+
+  # -- Additional annotations for the HTTPRoute resource
+  annotations: {}
+
+  # -- List of Gateways this HTTPRoute is attached to
+  parentRefs: []
+
+  # -- List of hostnames matching HTTP header
+  hostnames: []
+
+  # -- List of rules and filters applied to the HTTPRoute
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+
 # -- Backstage parameters
 # @default -- See below
 backstage:


### PR DESCRIPTION
## Description of the change

The Gateway API had been established as the new standard as an alternative for Ingress resources. With this change it's possible to deploy the HTTPRoute resource directly as part of the chart.

## Existing or Associated Issue(s)

None

## Additional Information

None

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
