### PR TITLE
Fix loadBalancerSourceRanges rendering in service template

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.8.0
+version: 2.8.1

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 2.8.0](https://img.shields.io/badge/Version-2.8.0-informational?style=flat-square)
+![Version: 2.8.1](https://img.shields.io/badge/Version-2.8.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application

--- a/charts/backstage/ci/loadBalancerSourceRanges-values.yaml
+++ b/charts/backstage/ci/loadBalancerSourceRanges-values.yaml
@@ -1,5 +1,0 @@
-service:
-  type: LoadBalancer
-  loadBalancerSourceRanges:
-    - 192.168.0.0/16
-    - 10.0.0.0/8

--- a/charts/backstage/ci/loadBalancerSourceRanges-values.yaml
+++ b/charts/backstage/ci/loadBalancerSourceRanges-values.yaml
@@ -1,0 +1,5 @@
+service:
+  type: LoadBalancer
+  loadBalancerSourceRanges:
+    - 192.168.0.0/16
+    - 10.0.0.0/8

--- a/charts/backstage/templates/service.yaml
+++ b/charts/backstage/templates/service.yaml
@@ -26,7 +26,8 @@ spec:
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
   {{- end }}
   {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges: {{ .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
   {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP)) }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}


### PR DESCRIPTION
Closes #326.

## What was wrong

`charts/backstage/templates/service.yaml` rendered `service.loadBalancerSourceRanges` by interpolating the slice directly:

```yaml
loadBalancerSourceRanges: {{ .Values.service.loadBalancerSourceRanges }}
```

When given a list of CIDRs, Go's default slice stringification produced output like `loadBalancerSourceRanges: [192.168.0.0/16 10.0.0.0/8]`, which is not a valid value for the Kubernetes `loadBalancerSourceRanges` field — Kubernetes expects a YAML list.

## The fix

Render the value with `toYaml | nindent`, matching the pattern already used for `ipFamilies` in the same file:

```yaml
loadBalancerSourceRanges:
  {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
```

## Test coverage

Added `charts/backstage/ci/loadBalancerSourceRanges-values.yaml` so `chart-testing` exercises the field with a representative pair of CIDRs and `service.type: LoadBalancer` (the field only applies for LoadBalancer services).
