### PR TITLE
fix: render extraVolumes without extraVolumeMounts

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.8.0
+version: 2.8.1

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 2.8.0](https://img.shields.io/badge/Version-2.8.0-informational?style=flat-square)
+![Version: 2.8.1](https://img.shields.io/badge/Version-2.8.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application

--- a/charts/backstage/ci/extraVolumes-sidecar-values.yaml
+++ b/charts/backstage/ci/extraVolumes-sidecar-values.yaml
@@ -1,0 +1,11 @@
+backstage:
+  extraVolumes:
+    - name: shared-cache
+      emptyDir: {}
+  extraContainers:
+    - name: sidecar
+      image: busybox:1.36
+      command: ["sh", "-c", "sleep 3600"]
+      volumeMounts:
+        - name: shared-cache
+          mountPath: /cache

--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -69,7 +69,7 @@ spec:
         {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.hostAliases "context" $) | nindent 8 }}
       {{- end }}
       volumes:
-        {{- if (or .Values.backstage.extraAppConfig (and .Values.backstage.extraVolumeMounts .Values.backstage.extraVolumes)) }}
+        {{- if (or .Values.backstage.extraAppConfig .Values.backstage.appConfig .Values.backstage.extraVolumes) }}
         {{- range .Values.backstage.extraAppConfig }}
         - name: {{ .configMapRef }}
           configMap:


### PR DESCRIPTION
## Description of the change

`backstage.extraVolumes` only rendered when `backstage.extraVolumeMounts` was also set on the main Backstage container.
That breaks sidecar or initContainer setups that mount the extra volume without mounting it in the main container.
This change renders `extraVolumes` on its own and adds a CI values case for a shared `emptyDir` volume.

## Existing or Associated Issue(s)

Didnt find a matching issue or PR in `backstage/charts`.

## Additional Information

Repro:

```yaml
backstage:
  extraVolumes:
    - name: shared-cache
      emptyDir: {}
  extraContainers:
    - name: sidecar
      image: busybox:1.36
      command: ["sh", "-c", "sleep 3600"]
      volumeMounts:
        - name: shared-cache
          mountPath: /cache
```

Run `helm template test charts/backstage -f values.yaml`.

Before this change, the sidecar mount renders but `spec.volumes` misses `shared-cache`.
After this change, the volume renders too.

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. No value docs changed in this PR.
- [x] JSON Schema generated. No schema changes were needed in this PR.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command. `ct` is not installed locally. I ran `helm lint` and `helm template` for the default chart, `ci/appConfig-values.yaml`, `ci/extraVolumes-values.yaml`, and the new sidecar repro.
