### PR TITLE
test: add helm-unittest coverage for configmap and servicemonitor

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -30,6 +30,17 @@ jobs:
       - name: Setup helm-docs
         run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
 
+      - name: Set up Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # pin@v4.3.1
+        with:
+          version: v3.16.4
+
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.0.3
+
+      - name: Build chart dependencies
+        run: helm dependency build charts/backstage
+
       - name: Run pre-commit
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # pin@v3.0.1
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,13 @@ repos:
         language: python
         types_or: [yaml, json]
 
+      - id: helm-unittest
+        name: helm-unittest
+        entry: helm unittest charts/backstage
+        language: system
+        files: ^charts/backstage/
+        pass_filenames: false
+
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:

--- a/charts/backstage/.helmignore
+++ b/charts/backstage/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+# Unit tests are not shipped with the packaged chart
+tests/

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.8.1
+version: 2.8.2

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 2.8.1](https://img.shields.io/badge/Version-2.8.1-informational?style=flat-square)
+![Version: 2.8.2](https://img.shields.io/badge/Version-2.8.2-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application

--- a/charts/backstage/tests/configmap_test.yaml
+++ b/charts/backstage/tests/configmap_test.yaml
@@ -1,0 +1,46 @@
+# Pins the behaviour of the app-config ConfigMap: it must only exist when the
+# user supplies backstage.appConfig, and when it does the rendered config has to
+# land verbatim under the app-config.yaml data key (this is what the deployment
+# mounts and passes to --config).
+suite: app-config configmap
+templates:
+  - app-config-configmap.yaml
+release:
+  name: backstage
+  namespace: backstage-system
+tests:
+  - it: does not render when backstage.appConfig is empty
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a single ConfigMap when backstage.appConfig is set
+    values:
+      - ../ci/appConfig-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: backstage-app-config
+      - equal:
+          path: metadata.namespace
+          value: backstage-system
+
+  - it: embeds the supplied config under the app-config.yaml key
+    values:
+      - ../ci/appConfig-values.yaml
+    asserts:
+      - isNotEmpty:
+          path: data["app-config.yaml"]
+      - matchRegex:
+          path: data["app-config.yaml"]
+          pattern: "title: The very best Backstage Helm Chart"
+      - matchRegex:
+          path: data["app-config.yaml"]
+          pattern: "baseUrl: https://somedomain.tl"
+      - matchRegex:
+          path: data["app-config.yaml"]
+          pattern: "port: 12345"

--- a/charts/backstage/tests/servicemonitor_test.yaml
+++ b/charts/backstage/tests/servicemonitor_test.yaml
@@ -1,0 +1,76 @@
+# Pins the ServiceMonitor behaviour: off by default, and when enabled it has to
+# render as a valid Prometheus Operator resource whose selector matches the
+# backstage Service and whose endpoint points at the configured port/path.
+suite: servicemonitor
+templates:
+  - servicemonitor.yaml
+release:
+  name: backstage
+  namespace: backstage-system
+tests:
+  - it: does not render when metrics.serviceMonitor is disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a ServiceMonitor when enabled
+    values:
+      - ../ci/service-monitor.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceMonitor
+      - equal:
+          path: apiVersion
+          value: monitoring.coreos.com/v1
+      - equal:
+          path: metadata.name
+          value: backstage
+
+  - it: targets the configured endpoint port and path
+    values:
+      - ../ci/service-monitor.yaml
+    asserts:
+      - equal:
+          path: spec.endpoints[0].port
+          value: http-backend
+      - equal:
+          path: spec.endpoints[0].path
+          value: /metrics
+      - notExists:
+          path: spec.endpoints[0].interval
+
+  - it: selects the backstage component within the release namespace
+    values:
+      - ../ci/service-monitor.yaml
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: backstage
+      - equal:
+          path: spec.namespaceSelector.matchNames[0]
+          value: backstage-system
+
+  - it: carries the standard component label plus user-supplied labels and annotations
+    values:
+      - ../ci/service-monitor.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: backstage
+      - equal:
+          path: metadata.labels.test
+          value: test
+      - equal:
+          path: metadata.annotations.test
+          value: test
+
+  - it: emits the scrape interval only when configured
+    set:
+      metrics.serviceMonitor.enabled: true
+      metrics.serviceMonitor.interval: 30s
+    asserts:
+      - equal:
+          path: spec.endpoints[0].interval
+          value: 30s


### PR DESCRIPTION
First helm-unittest suites for the backstage chart, part of #335.

- `app-config` ConfigMap — only renders when `backstage.appConfig` is set, and embeds the config under the `app-config.yaml` key
- ServiceMonitor — off by default, and when enabled has the right kind/apiVersion, endpoint port/path, selector, and labels

Tests run via a pre-commit hook and a new CI job (`helm unittest charts/backstage`) on every PR.