### PR TITLE
feat: allow configuring pod priority class

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.8.2
+version: 2.9.0

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 2.8.2](https://img.shields.io/badge/Version-2.8.2-informational?style=flat-square)
+![Version: 2.9.0](https://img.shields.io/badge/Version-2.9.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
@@ -144,6 +144,7 @@ Kubernetes: `>= 1.19.0-0`
 | backstage.podAnnotations | Annotations to add to the backend deployment pods | object | `{}` |
 | backstage.podLabels | Labels to add to the backend deployment pods | object | `{}` |
 | backstage.podSecurityContext | Security settings for a Pod.  The security settings that you specify for a Pod apply to all Containers in the Pod. <br /> Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod | object | `{}` |
+| backstage.priorityClassName | Priority class name for pod scheduling <br /> Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/ | string | `""` |
 | backstage.readinessProbe | Readiness Probe Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes <!-- E.g. readinessProbe:   failureThreshold: 3   httpGet:     path: /.backstage/health/v1/readiness     port: 7007     scheme: HTTP   initialDelaySeconds: 30   periodSeconds: 10   successThreshold: 2   timeoutSeconds: 2 | object | `{"httpGet":{"path":"/.backstage/health/v1/readiness","port":7007,"scheme":"HTTP"}}` |
 | backstage.replicas | Number of deployment replicas | int | `1` |
 | backstage.resources | Resource requests/limits <br /> Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container <!-- E.g. resources:   limits:     memory: 1Gi     cpu: 1000m   requests:     memory: 250Mi     cpu: 100m --> | object | `{}` |

--- a/charts/backstage/ci/priorityClassName-values.yaml
+++ b/charts/backstage/ci/priorityClassName-values.yaml
@@ -1,0 +1,11 @@
+backstage:
+  priorityClassName: backstage-chart-test
+
+extraDeploy:
+  - apiVersion: scheduling.k8s.io/v1
+    kind: PriorityClass
+    metadata:
+      name: backstage-chart-test
+    value: 1000
+    globalDefault: false
+    description: Priority class used to test the Backstage chart

--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -44,6 +44,9 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "backstage.serviceAccountName" . }}
+      {{- if .Values.backstage.priorityClassName }}
+      priorityClassName: {{ .Values.backstage.priorityClassName | quote }}
+      {{- end }}
       {{- if .Values.backstage.podSecurityContext }}
       securityContext:
         {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.podSecurityContext "context" $) | nindent 8 }}

--- a/charts/backstage/tests/deployment_test.yaml
+++ b/charts/backstage/tests/deployment_test.yaml
@@ -1,0 +1,21 @@
+# Pins the priority class behaviour: it is omitted by default and, when set,
+# maps to the Backstage pod specification.
+suite: backstage deployment
+templates:
+  - backstage-deployment.yaml
+release:
+  name: backstage
+  namespace: backstage-system
+tests:
+  - it: omits the priority class name by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+
+  - it: configures the priority class name when set
+    values:
+      - ../ci/priorityClassName-values.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: backstage-chart-test

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -5750,6 +5750,12 @@
                     },
                     "type": "object"
                 },
+                "priorityClassName": {
+                    "default": "",
+                    "description": "Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/",
+                    "title": "Priority class name for pod scheduling",
+                    "type": "string"
+                },
                 "readinessProbe": {
                     "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
                     "properties": {

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -856,6 +856,12 @@
                     "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.4/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
                     "default": {}
                 },
+                "priorityClassName": {
+                    "title": "Priority class name for pod scheduling",
+                    "description": "Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/",
+                    "type": "string",
+                    "default": ""
+                },
                 "containerSecurityContext": {
                     "title": "Security settings for a Container.",
                     "description": "Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container",

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -299,6 +299,10 @@ backstage:
   # <br /> Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   podSecurityContext: {}
 
+  # -- Priority class name for pod scheduling
+  # <br /> Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+  priorityClassName: ""
+
   # -- Security settings for a Container.
   # <br /> Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   containerSecurityContext: {}


### PR DESCRIPTION
## Description of the change

Adds a new optional `backstage.priorityClassName` value and maps it to `spec.template.spec.priorityClassName` in the Backstage Deployment.

The value defaults to an empty string and the field is omitted when unset, preserving the existing scheduling behavior. Operators can now associate Backstage pods with an existing Kubernetes `PriorityClass`.

This change also:

- documents the new value;
- updates the source and generated JSON schemas;
- adds unit coverage for both the default and configured behavior;
- adds a CI values fixture with a dedicated test `PriorityClass`;
- bumps the chart version from `2.8.2` to `2.9.0`.

## Existing or Associated Issue(s)

N/A.

## Additional Information

Validation performed:

- `helm template` with default and configured values;
- `helm lint`;
- `helm unittest` — 11 tests passed;
- `pre-commit run --all-files`;
- `ct lint`.

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in `values.yaml` and added to `README.md`.
- [x] JSON Schema generated.
- [x] Chart Testing lint passes with `ct lint`.