### PR TITLE
feat: allow configuring lifecycle hooks and termination grace period

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.9.0
+version: 2.10.0

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 2.9.0](https://img.shields.io/badge/Version-2.9.0-informational?style=flat-square)
+![Version: 2.10.0](https://img.shields.io/badge/Version-2.10.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
@@ -138,6 +138,7 @@ Kubernetes: `>= 1.19.0-0`
 | backstage.image.tag | Backstage image tag (immutable tags are recommended) | string | `"latest"` |
 | backstage.initContainers | Backstage container init containers | list | `[]` |
 | backstage.installDir | Directory containing the backstage installation | string | `"/app"` |
+| backstage.lifecycleHooks | Lifecycle hooks for the Backstage container <br /> Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/ <!-- E.g. lifecycleHooks:   preStop:     exec:       command: ["/bin/sh", "-c", "sleep 10"] --> | object | `{}` |
 | backstage.livenessProbe | Liveness Probe Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes <!-- E.g. livenessProbe:   failureThreshold: 3   httpGet:     path: /.backstage/health/v1/liveness     port: 7007     scheme: HTTP   initialDelaySeconds: 60   periodSeconds: 10   successThreshold: 1   timeoutSeconds: 2 | object | `{"httpGet":{"path":"/.backstage/health/v1/liveness","port":7007,"scheme":"HTTP"}}` |
 | backstage.nodeSelector | Node labels for pod assignment <br /> Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector | object | `{}` |
 | backstage.pdb | Pod Disruption Budget configuration ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/ | object | `{"create":false,"maxUnavailable":"","minAvailable":""}` |
@@ -151,6 +152,7 @@ Kubernetes: `>= 1.19.0-0`
 | backstage.revisionHistoryLimit | Define the [count of deployment revisions](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) to be kept. May be set to 0 in case of GitOps deployment approach. | int | `10` |
 | backstage.startupProbe | Startup Probe Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes <!-- E.g. startupProbe:   failureThreshold: 3   httpGet:     path: /.backstage/health/v1/liveness     port: 7007     scheme: HTTP   initialDelaySeconds: 60   periodSeconds: 10   successThreshold: 1   timeoutSeconds: 2 | object | `{"httpGet":{"path":"/.backstage/health/v1/liveness","port":7007,"scheme":"HTTP"}}` |
 | backstage.strategy | Deployment [update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy). When unset, Kubernetes applies its default (RollingUpdate with maxSurge 25% and maxUnavailable 25%). Set to `Recreate` (or `RollingUpdate` with `maxSurge: 0`) to guarantee a single Backstage pod runs at a time, which is recommended when plugin database migrations run on startup to avoid concurrent migration attempts. <!-- E.g. strategy:   type: RollingUpdate   rollingUpdate:     maxSurge: 0     maxUnavailable: 1 --> | object | `{}` |
+| backstage.terminationGracePeriodSeconds | Duration in seconds the pod needs to terminate gracefully before being force killed <br /> Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination <!-- E.g. terminationGracePeriodSeconds: 60 --> | string | `nil` |
 | backstage.tolerations | Node tolerations for server scheduling to nodes with taints <br /> Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ | list | `[]` |
 | backstage.topologySpreadConstraints | Topology Spread Constraints for pod assignment <br /> Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#pod-topology-spread-constraints | list | `[]` |
 | clusterDomain | Default Kubernetes cluster domain | string | `"cluster.local"` |

--- a/charts/backstage/ci/lifecycle-values.yaml
+++ b/charts/backstage/ci/lifecycle-values.yaml
@@ -1,0 +1,6 @@
+backstage:
+  lifecycleHooks:
+    preStop:
+      exec:
+        command: ["/bin/sh", "-c", "sleep 10"]
+  terminationGracePeriodSeconds: 60

--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -71,6 +71,9 @@ spec:
       hostAliases:
         {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.hostAliases "context" $) | nindent 8 }}
       {{- end }}
+      {{- if not (kindIs "invalid" .Values.backstage.terminationGracePeriodSeconds) }}
+      terminationGracePeriodSeconds: {{ .Values.backstage.terminationGracePeriodSeconds }}
+      {{- end }}
       volumes:
         {{- if (or .Values.backstage.extraAppConfig (and .Values.backstage.extraVolumeMounts .Values.backstage.extraVolumes)) }}
         {{- range .Values.backstage.extraAppConfig }}
@@ -135,6 +138,9 @@ spec:
           {{- end }}
           {{- if .Values.backstage.startupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.backstage.startupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.backstage.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.backstage.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
           {{- if (or .Values.backstage.extraEnvVarsCM .Values.backstage.extraEnvVarsSecrets) }}
           envFrom:

--- a/charts/backstage/tests/deployment_test.yaml
+++ b/charts/backstage/tests/deployment_test.yaml
@@ -1,5 +1,5 @@
-# Pins the priority class behaviour: it is omitted by default and, when set,
-# maps to the Backstage pod specification.
+# Pins the optional pod settings: each is omitted by default and, when set, maps to the
+# Backstage pod specification or container.
 suite: backstage deployment
 templates:
   - backstage-deployment.yaml
@@ -19,3 +19,34 @@ tests:
       - equal:
           path: spec.template.spec.priorityClassName
           value: backstage-chart-test
+
+  - it: renders neither lifecycle hooks nor a termination grace period by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.terminationGracePeriodSeconds
+      - notExists:
+          path: spec.template.spec.containers[0].lifecycle
+
+  - it: renders the preStop hook on the backstage container
+    values:
+      - ../ci/lifecycle-values.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value: ["/bin/sh", "-c", "sleep 10"]
+
+  - it: renders the termination grace period on the pod spec
+    values:
+      - ../ci/lifecycle-values.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 60
+
+  - it: renders a termination grace period of zero
+    set:
+      backstage.terminationGracePeriodSeconds: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 0

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -5399,6 +5399,238 @@
                     "title": "Directory containing the backstage installation",
                     "type": "string"
                 },
+                "lifecycleHooks": {
+                    "description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
+                    "properties": {
+                        "postStart": {
+                            "description": "LifecycleHandler defines a specific action that should be taken in a lifecycle hook. One and only one of the fields, except TCPSocket must be specified.",
+                            "properties": {
+                                "exec": {
+                                    "description": "ExecAction describes a \"run in container\" action.",
+                                    "properties": {
+                                        "command": {
+                                            "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "httpGet": {
+                                    "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                    "properties": {
+                                        "host": {
+                                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                            "type": "string"
+                                        },
+                                        "httpHeaders": {
+                                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                            "items": {
+                                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                "properties": {
+                                                    "name": {
+                                                        "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "description": "The header field value",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "value"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "path": {
+                                            "description": "Path to access on the HTTP server.",
+                                            "type": "string"
+                                        },
+                                        "port": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "integer"
+                                                }
+                                            ]
+                                        },
+                                        "scheme": {
+                                            "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "port"
+                                    ],
+                                    "type": "object"
+                                },
+                                "sleep": {
+                                    "description": "SleepAction describes a \"sleep\" action.",
+                                    "properties": {
+                                        "seconds": {
+                                            "description": "Seconds is the number of seconds to sleep.",
+                                            "format": "int64",
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "required": [
+                                        "seconds"
+                                    ],
+                                    "type": "object"
+                                },
+                                "tcpSocket": {
+                                    "description": "TCPSocketAction describes an action based on opening a socket",
+                                    "properties": {
+                                        "host": {
+                                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                            "type": "string"
+                                        },
+                                        "port": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "integer"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "port"
+                                    ],
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "preStop": {
+                            "description": "LifecycleHandler defines a specific action that should be taken in a lifecycle hook. One and only one of the fields, except TCPSocket must be specified.",
+                            "properties": {
+                                "exec": {
+                                    "description": "ExecAction describes a \"run in container\" action.",
+                                    "properties": {
+                                        "command": {
+                                            "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "httpGet": {
+                                    "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                    "properties": {
+                                        "host": {
+                                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                            "type": "string"
+                                        },
+                                        "httpHeaders": {
+                                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                            "items": {
+                                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                "properties": {
+                                                    "name": {
+                                                        "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "description": "The header field value",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "value"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "path": {
+                                            "description": "Path to access on the HTTP server.",
+                                            "type": "string"
+                                        },
+                                        "port": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "integer"
+                                                }
+                                            ]
+                                        },
+                                        "scheme": {
+                                            "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "port"
+                                    ],
+                                    "type": "object"
+                                },
+                                "sleep": {
+                                    "description": "SleepAction describes a \"sleep\" action.",
+                                    "properties": {
+                                        "seconds": {
+                                            "description": "Seconds is the number of seconds to sleep.",
+                                            "format": "int64",
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "required": [
+                                        "seconds"
+                                    ],
+                                    "type": "object"
+                                },
+                                "tcpSocket": {
+                                    "description": "TCPSocketAction describes an action based on opening a socket",
+                                    "properties": {
+                                        "host": {
+                                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                            "type": "string"
+                                        },
+                                        "port": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "integer"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "port"
+                                    ],
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "stopSignal": {
+                            "description": "StopSignal defines which signal will be sent to a container when it is being stopped. If not specified, the default is defined by the container runtime in use. StopSignal can only be set for Pods with a non-empty .spec.os.name",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
                 "livenessProbe": {
                     "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
                     "properties": {
@@ -6134,6 +6366,19 @@
                     ],
                     "title": "Deployment update strategy",
                     "type": "object"
+                },
+                "terminationGracePeriodSeconds": {
+                    "default": null,
+                    "description": "Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination",
+                    "examples": [
+                        60
+                    ],
+                    "minimum": 0,
+                    "title": "Duration in seconds the pod needs to terminate gracefully before being force killed",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "tolerations": {
                     "default": [],

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -850,6 +850,25 @@
                         }
                     ]
                 },
+                "lifecycleHooks": {
+                    "title": "Lifecycle hooks for the Backstage container",
+                    "description": "Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/",
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.4/_definitions.json#/definitions/io.k8s.api.core.v1.Lifecycle",
+                    "default": {},
+                    "examples": [
+                        {
+                            "preStop": {
+                                "exec": {
+                                    "command": [
+                                        "/bin/sh",
+                                        "-c",
+                                        "sleep 10"
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                },
                 "podSecurityContext": {
                     "title": "Security settings for a Pod.",
                     "description": "The security settings that you specify for a Pod apply to all Containers in the Pod. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod",
@@ -909,6 +928,19 @@
                         "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.4/_definitions.json#/definitions/io.k8s.api.core.v1.HostAlias"
                     },
                     "default": []
+                },
+                "terminationGracePeriodSeconds": {
+                    "title": "Duration in seconds the pod needs to terminate gracefully before being force killed",
+                    "description": "Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination",
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "minimum": 0,
+                    "default": null,
+                    "examples": [
+                        60
+                    ]
                 },
                 "podAnnotations": {
                     "title": "Annotations to add to the backend deployment pods",

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -294,6 +294,15 @@ backstage:
       port: 7007
       scheme: HTTP
 
+  # -- Lifecycle hooks for the Backstage container
+  # <br /> Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  # <!-- E.g.
+  # lifecycleHooks:
+  #   preStop:
+  #     exec:
+  #       command: ["/bin/sh", "-c", "sleep 10"] -->
+  lifecycleHooks: {}
+
   # -- Security settings for a Pod.
   #  The security settings that you specify for a Pod apply to all Containers in the Pod.
   # <br /> Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
@@ -340,6 +349,12 @@ backstage:
   # -- Host Aliases for the pod
   # <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   hostAliases: []
+
+  # -- Duration in seconds the pod needs to terminate gracefully before being force killed
+  # <br /> Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+  # <!-- E.g.
+  # terminationGracePeriodSeconds: 60 -->
+  terminationGracePeriodSeconds: null
 
   # -- Annotations to add to the backend deployment pods
   podAnnotations: {}


### PR DESCRIPTION
## Description of the change

Adds two optional values that map to the Backstage Deployment:

- `backstage.lifecycleHooks` to `spec.template.spec.containers[0].lifecycle`
- `backstage.terminationGracePeriodSeconds` to `spec.template.spec.terminationGracePeriodSeconds`

Both are unset by default and omitted from the rendered manifest when not configured, so existing installations are unaffected.

The motivating use case is graceful shutdown during rolling updates. Endpoint removal and SIGTERM delivery are not ordered in Kubernetes (kubernetes/kubernetes#106476), and the Backstage backend's lifecycle middleware fails incoming requests with `503 ServiceUnavailableError: Service is shutting down` as soon as SIGTERM arrives - so requests routed to a terminating pod during the propagation window are rejected. The standard mitigation is a short `preStop` sleep so the pod keeps serving while it is removed from endpoints, with `terminationGracePeriodSeconds` raised to keep the application's shutdown budget intact.

## Existing or Associated Issue(s)

None.

## Additional Information

- The grace period uses a nil-safe template guard (`kindIs "invalid"`) so an explicit `0` - valid in Kubernetes, meaning immediate kill - renders rather than being silently dropped; a unit test pins this.

Validation performed:

- `helm template`
- `helm lint`
- `helm unittest`
- `pre-commit run --all-files`
- `ct lint`

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
