### PR TITLE
test(backstage): complete chart unit test coverage

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.10.0
+version: 2.10.1

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/backstage)](https://artifacthub.io/packages/search?repo=backstage)
-![Version: 2.10.0](https://img.shields.io/badge/Version-2.10.0-informational?style=flat-square)
+![Version: 2.10.1](https://img.shields.io/badge/Version-2.10.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application

--- a/charts/backstage/templates/_helpers.tpl
+++ b/charts/backstage/templates/_helpers.tpl
@@ -47,9 +47,9 @@ Return the Postgres Database Secret Name
 */}}
 {{- define "backstage.postgresql.databaseSecretName" -}}
 {{- if ((((.Values).global).postgresql).auth).existingSecret }}
-    {{- tpl .Values.global.postgresql.auth.existingSecret $ -}}
+    {{- tpl .Values.global.postgresql.auth.existingSecret $ | required "global.postgresql.auth.existingSecret must render to a non-empty secret name" -}}
 {{- else if .Values.postgresql.auth.existingSecret }}
-    {{- tpl .Values.postgresql.auth.existingSecret $ -}}
+    {{- tpl .Values.postgresql.auth.existingSecret $ | required "postgresql.auth.existingSecret must render to a non-empty secret name" -}}
 {{- else -}}
     {{- default (include "backstage.postgresql.fullname" .) (tpl .Values.postgresql.auth.existingSecret $) -}}
 {{- end -}}

--- a/charts/backstage/templates/app-config-configmap.yaml
+++ b/charts/backstage/templates/app-config-configmap.yaml
@@ -4,6 +4,15 @@ kind: ConfigMap
 metadata:
   name: {{ include "common.names.fullname" . }}-app-config
   namespace: {{ .Release.Namespace | quote }}
+  labels: {{ include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: backstage
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  {{- end }}
 data:
   app-config.yaml: |
     {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.appConfig "context" $) | nindent 4 }}

--- a/charts/backstage/templates/pdb.yaml
+++ b/charts/backstage/templates/pdb.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.backstage.pdb.create }}
+{{- if and .Values.backstage.pdb.minAvailable .Values.backstage.pdb.maxUnavailable }}
+{{- fail "backstage.pdb.minAvailable and backstage.pdb.maxUnavailable are mutually exclusive" }}
+{{- end }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/backstage/templates/serviceaccount.yaml
+++ b/charts/backstage/templates/serviceaccount.yaml
@@ -4,13 +4,19 @@ kind: ServiceAccount
 metadata:
   name: {{ include "backstage.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
-  labels:
+  labels: {{ include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: backstage
+    {{- with .Values.commonLabels }}
+    {{- include "common.tplvalues.render" (dict "value" . "context" $) | trim | nindent 4 }}
+    {{- end }}
     {{- with .Values.serviceAccount.labels }}
     {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | trim | nindent 4 }}
     {{- end }}
-  {{- if .Values.serviceAccount.annotations }}
+  {{- if or .Values.commonAnnotations .Values.serviceAccount.annotations }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" (dict "value" . "context" $) | trim | nindent 4 }}
+    {{- end }}
     {{- with .Values.serviceAccount.annotations }}
     {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | trim | nindent 4 }}
     {{- end }}

--- a/charts/backstage/tests/cross_cutting_test.yaml
+++ b/charts/backstage/tests/cross_cutting_test.yaml
@@ -1,0 +1,108 @@
+suite: backstage cross-cutting settings
+templates:
+  - app-config-configmap.yaml
+  - backstage-deployment.yaml
+  - hpa.yaml
+  - httproute.yaml
+  - ingress.yaml
+  - networkpolicy-egress.yaml
+  - networkpolicy.yaml
+  - pdb.yaml
+  - service.yaml
+  - serviceaccount.yaml
+  - servicemonitor.yaml
+release:
+  name: backstage
+  namespace: backstage-system
+set:
+  backstage.appConfig:
+    app:
+      title: Backstage
+  backstage.autoscaling.enabled: true
+  backstage.pdb.create: true
+  httpRoute.enabled: true
+  ingress.enabled: true
+  metrics.serviceMonitor.enabled: true
+  networkPolicy.enabled: true
+  networkPolicy.ingressRules.namespaceSelector:
+    team: platform
+  networkPolicy.egressRules.denyConnectionsToExternal: true
+  serviceAccount.create: true
+tests:
+  - it: applies nameOverride when fullnameOverride is absent
+    set:
+      nameOverride: platform
+    asserts:
+      - equal:
+          path: metadata.name
+          value: backstage-platform
+        template: backstage-deployment.yaml
+      - equal:
+          path: metadata.name
+          value: backstage-platform
+        template: service.yaml
+
+  - it: gives fullnameOverride precedence across resources
+    set:
+      nameOverride: platform
+      fullnameOverride: backstage-custom
+    asserts:
+      - equal:
+          path: metadata.name
+          value: backstage-custom-app-config
+        template: app-config-configmap.yaml
+      - equal:
+          path: metadata.name
+          value: backstage-custom
+        template: backstage-deployment.yaml
+      - equal:
+          path: metadata.name
+          value: backstage-custom
+        template: hpa.yaml
+      - equal:
+          path: metadata.name
+          value: backstage-custom
+        template: httproute.yaml
+      - equal:
+          path: metadata.name
+          value: backstage-custom
+        template: ingress.yaml
+      - equal:
+          path: metadata.name
+          value: backstage-custom-egress
+        template: networkpolicy-egress.yaml
+      - equal:
+          path: metadata.name
+          value: backstage-custom
+        template: networkpolicy.yaml
+      - equal:
+          path: metadata.name
+          value: backstage-custom
+        template: pdb.yaml
+      - equal:
+          path: metadata.name
+          value: backstage-custom
+        template: service.yaml
+      - equal:
+          path: metadata.name
+          value: backstage-custom
+        template: serviceaccount.yaml
+      - equal:
+          path: metadata.name
+          value: backstage-custom
+        template: servicemonitor.yaml
+
+  - it: propagates rendered common metadata to every resource
+    set:
+      clusterDomain: internal.example
+      commonLabels:
+        cluster-domain: '{{ .Values.clusterDomain }}'
+      commonAnnotations:
+        example.com/cluster-domain: '{{ .Values.clusterDomain }}'
+    asserts:
+      - equal:
+          path: metadata.labels.cluster-domain
+          value: internal.example
+      - equal:
+          path: metadata.annotations["example.com/cluster-domain"]
+          value: internal.example

--- a/charts/backstage/tests/deployment_test.yaml
+++ b/charts/backstage/tests/deployment_test.yaml
@@ -1,5 +1,3 @@
-# Pins the optional pod settings: each is omitted by default and, when set, maps to the
-# Backstage pod specification or container.
 suite: backstage deployment
 templates:
   - backstage-deployment.yaml
@@ -7,6 +5,372 @@ release:
   name: backstage
   namespace: backstage-system
 tests:
+  - it: renders one Deployment with the expected identity
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: backstage
+      - equal:
+          path: metadata.namespace
+          value: backstage-system
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: backstage
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: backstage
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: backstage
+
+  - it: uses selector labels that are present on the pod
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: backstage
+            app.kubernetes.io/instance: backstage
+            app.kubernetes.io/component: backstage
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: backstage
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
+          value: backstage
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: backstage
+
+  - it: renders the configured image registry and repository
+    set:
+      backstage.image.registry: registry.example.com
+      backstage.image.repository: platform/backstage
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^registry\\.example\\.com/platform/backstage:"
+
+  - it: lets the global registry override the image registry
+    set:
+      global.imageRegistry: global.example.com
+      backstage.image.registry: registry.example.com
+      backstage.image.repository: platform/backstage
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^global\\.example\\.com/platform/backstage:"
+
+  - it: pins the image by digest instead of tag
+    values:
+      - ../ci/image-digest-values.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/backstage/backstage@sha256:f9ffa809e2c3f351699129d57edd6e64ca9ea5a4d4dd6339fed1ec80a30bc042
+
+  - it: renders a static replica count by default
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: omits the static replica count when autoscaling is enabled
+    values:
+      - ../ci/autoscaling-values.yaml
+    asserts:
+      - notExists:
+          path: spec.replicas
+
+  - it: omits the update strategy by default
+    asserts:
+      - notExists:
+          path: spec.strategy
+
+  - it: renders the configured update strategy
+    values:
+      - ../ci/strategy-values.yaml
+    asserts:
+      - equal:
+          path: spec.strategy
+          value:
+            type: RollingUpdate
+            rollingUpdate:
+              maxSurge: 0
+              maxUnavailable: 1
+
+  - it: renders the configured readiness liveness and startup probes
+    values:
+      - ../ci/probes-values.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            failureThreshold: 3
+            httpGet:
+              path: /.backstage/health/v1/readiness
+              port: 7007
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 2
+            timeoutSeconds: 2
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            failureThreshold: 3
+            httpGet:
+              path: /.backstage/health/v1/liveness
+              port: 7007
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            failureThreshold: 3
+            httpGet:
+              path: /.backstage/health/v1/liveness
+              port: 7007
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
+
+  - it: omits readiness liveness and startup probes when disabled
+    set:
+      backstage.readinessProbe: null
+      backstage.livenessProbe: null
+      backstage.startupProbe: null
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe
+
+  - it: mounts generated app config and passes it to Backstage
+    values:
+      - ../ci/appConfig-values.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: backstage-app-config
+            configMap:
+              name: backstage-app-config
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: backstage-app-config
+            mountPath: /app/app-config-from-configmap.yaml
+            subPath: app-config.yaml
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - --config
+            - /app/app-config-from-configmap.yaml
+
+  - it: wires credentials generated by the PostgreSQL subchart
+    values:
+      - ../ci/postgres-generated-creds-values.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_HOST
+            value: backstage-postgresql
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_USER
+            value: bn_backstage
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: backstage-postgresql
+                key: password
+
+  - it: wires credentials from a provided PostgreSQL secret
+    set:
+      postgresql.enabled: true
+      postgresql.auth.existingSecret: backstage-database-credentials
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: backstage-database-credentials
+                key: user-password
+
+  - it: renders extra environment variables
+    set:
+      backstage.extraEnvVars:
+        - name: LOG_LEVEL
+          value: debug
+        - name: API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: backstage-api
+              key: token
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LOG_LEVEL
+            value: debug
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: API_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: backstage-api
+                key: token
+
+  - it: renders matching extra volumes and volume mounts
+    values:
+      - ../ci/extraVolumes-values.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: test
+            emptyDir:
+              sizeLimit: 5Mi
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: test
+            mountPath: /somepath
+            readOnly: true
+
+  - it: renders topology spread constraints
+    values:
+      - ../ci/topologySpreadConstraints-values.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints
+          value:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: DoNotSchedule
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: backstage
+              matchLabelKeys:
+                - pod-template-hash
+
+  - it: renders node selector affinity and tolerations
+    set:
+      backstage.nodeSelector:
+        kubernetes.io/os: linux
+      backstage.affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-pool
+                    operator: In
+                    values:
+                      - backstage
+      backstage.tolerations:
+        - key: dedicated
+          operator: Equal
+          value: backstage
+          effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            kubernetes.io/os: linux
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0]
+          value:
+            key: node-pool
+            operator: In
+            values:
+              - backstage
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - key: dedicated
+              operator: Equal
+              value: backstage
+              effect: NoSchedule
+
+  - it: renders pod and container security contexts
+    set:
+      backstage.podSecurityContext:
+        runAsNonRoot: true
+        fsGroup: 2000
+      backstage.containerSecurityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            runAsNonRoot: true
+            fsGroup: 2000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+
+  - it: renders init containers and extra containers
+    set:
+      backstage.initContainers:
+        - name: wait-for-service
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - echo ready
+      backstage.extraContainers:
+        - name: metrics-sidecar
+          image: example.com/metrics:1.0
+          ports:
+            - name: metrics
+              containerPort: 9090
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0]
+          value:
+            name: wait-for-service
+            image: busybox:1.36
+            command:
+              - sh
+              - -c
+              - echo ready
+      - equal:
+          path: spec.template.spec.containers[1]
+          value:
+            name: metrics-sidecar
+            image: example.com/metrics:1.0
+            ports:
+              - name: metrics
+                containerPort: 9090
+
   - it: omits the priority class name by default
     asserts:
       - notExists:

--- a/charts/backstage/tests/deployment_test.yaml
+++ b/charts/backstage/tests/deployment_test.yaml
@@ -371,6 +371,32 @@ tests:
               - name: metrics
                 containerPort: 9090
 
+  - it: references the generated ServiceAccount name
+    set:
+      serviceAccount.create: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: backstage
+
+  - it: gives the configured ServiceAccount name precedence
+    set:
+      serviceAccount.create: true
+      serviceAccount.name: backstage-runtime
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: backstage-runtime
+
+  - it: references an existing ServiceAccount when creation is disabled
+    set:
+      serviceAccount.create: false
+      serviceAccount.name: backstage-existing
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: backstage-existing
+
   - it: omits the priority class name by default
     asserts:
       - notExists:

--- a/charts/backstage/tests/extra_deploy_test.yaml
+++ b/charts/backstage/tests/extra_deploy_test.yaml
@@ -1,0 +1,39 @@
+suite: backstage extra deployment objects
+templates:
+  - extra-list.yaml
+release:
+  name: backstage
+  namespace: backstage-system
+tests:
+  - it: renders arbitrary manifests
+    values:
+      - ../ci/extraDeploy-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: foo
+      - equal:
+          path: data.bar
+          value: baz
+
+  - it: evaluates templated strings in arbitrary manifests
+    set:
+      clusterDomain: internal.example
+      extraDeploy:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: '{{ .Release.Name }}-extra'
+          data:
+            clusterDomain: '{{ .Values.clusterDomain }}'
+    asserts:
+      - equal:
+          path: metadata.name
+          value: backstage-extra
+      - equal:
+          path: data.clusterDomain
+          value: internal.example

--- a/charts/backstage/tests/hpa_test.yaml
+++ b/charts/backstage/tests/hpa_test.yaml
@@ -1,0 +1,90 @@
+suite: backstage horizontal pod autoscaler
+templates:
+  - hpa.yaml
+release:
+  name: backstage
+  namespace: backstage-system
+tests:
+  - it: does not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders when autoscaling is enabled
+    values:
+      - ../ci/autoscaling-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: apiVersion
+          value: autoscaling/v2
+
+  - it: renders replica limits and both configured metrics
+    values:
+      - ../ci/autoscaling-values.yaml
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 1
+      - equal:
+          path: spec.maxReplicas
+          value: 3
+      - equal:
+          path: spec.metrics
+          value:
+            - type: Resource
+              resource:
+                name: cpu
+                target:
+                  type: Utilization
+                  averageUtilization: 75
+            - type: Resource
+              resource:
+                name: memory
+                target:
+                  type: Utilization
+                  averageUtilization: 90
+
+  - it: renders only the CPU metric when memory is unset
+    set:
+      backstage.autoscaling.enabled: true
+    asserts:
+      - equal:
+          path: spec.metrics
+          value:
+            - type: Resource
+              resource:
+                name: cpu
+                target:
+                  type: Utilization
+                  averageUtilization: 80
+
+  - it: renders only the memory metric when CPU is unset
+    set:
+      backstage.autoscaling.enabled: true
+      backstage.autoscaling.targetCPUUtilizationPercentage: null
+      backstage.autoscaling.targetMemoryUtilizationPercentage: 85
+    asserts:
+      - equal:
+          path: spec.metrics
+          value:
+            - type: Resource
+              resource:
+                name: memory
+                target:
+                  type: Utilization
+                  averageUtilization: 85
+
+  - it: targets the Backstage Deployment
+    set:
+      backstage.autoscaling.enabled: true
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef
+          value:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: backstage

--- a/charts/backstage/tests/httproute_test.yaml
+++ b/charts/backstage/tests/httproute_test.yaml
@@ -1,0 +1,51 @@
+suite: backstage HTTPRoute
+templates:
+  - httproute.yaml
+release:
+  name: backstage
+  namespace: backstage-system
+tests:
+  - it: does not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a v1 HTTPRoute when enabled
+    values:
+      - ../ci/httproute-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+
+  - it: renders parent references hostnames and rules
+    values:
+      - ../ci/httproute-values.yaml
+    asserts:
+      - equal:
+          path: spec.parentRefs
+          value:
+            - name: default
+              namespace: proxy
+      - equal:
+          path: spec.hostnames
+          value:
+            - backstage.example.com
+      - equal:
+          path: spec.rules[0].matches[0].path
+          value:
+            type: PathPrefix
+            value: /
+      - equal:
+          path: spec.rules[0].timeouts.request
+          value: 10s
+      - equal:
+          path: spec.rules[0].backendRefs[0]
+          value:
+            name: backstage
+            port: 7007
+            weight: 1

--- a/charts/backstage/tests/ingress_test.yaml
+++ b/charts/backstage/tests/ingress_test.yaml
@@ -1,0 +1,79 @@
+suite: backstage ingress
+templates:
+  - ingress.yaml
+release:
+  name: backstage
+  namespace: backstage-system
+tests:
+  - it: does not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders when enabled
+    values:
+      - ../ci/ingress-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - equal:
+          path: apiVersion
+          value: networking.k8s.io/v1
+
+  - it: renders the host path class and TLS settings
+    values:
+      - ../ci/ingress-values.yaml
+    set:
+      ingress.className: nginx
+      ingress.path: /backstage
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+      - equal:
+          path: spec.rules[0].host
+          value: backstage.example.com
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /backstage
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Prefix
+      - equal:
+          path: spec.tls[0]
+          value:
+            hosts:
+              - backstage.example.com
+            secretName: backstage-tls
+
+  - it: renders additional hosts and TLS entries
+    values:
+      - ../ci/ingress-extraHosts-values.yaml
+    asserts:
+      - equal:
+          path: spec.rules[1].host
+          value: backstage.dev.example.com
+      - equal:
+          path: spec.rules[1].http.paths[0].path
+          value: /
+      - equal:
+          path: spec.rules[1].http.paths[0].pathType
+          value: Prefix
+      - equal:
+          path: spec.tls[1]
+          value:
+            hosts:
+              - backstage.dev.example.com
+            secretName: backstage-dev-tls
+
+  - it: passes annotations through to the Ingress
+    set:
+      ingress.enabled: true
+      ingress.annotations:
+        nginx.ingress.kubernetes.io/proxy-body-size: 10m
+    asserts:
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-body-size"]
+          value: 10m

--- a/charts/backstage/tests/networkpolicy_egress_test.yaml
+++ b/charts/backstage/tests/networkpolicy_egress_test.yaml
@@ -1,0 +1,69 @@
+suite: backstage egress network policy
+templates:
+  - networkpolicy-egress.yaml
+release:
+  name: backstage
+  namespace: backstage-system
+tests:
+  - it: does not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render when egress restrictions are off
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders DNS and namespace egress when external connections are denied
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egressRules.denyConnectionsToExternal: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: metadata.name
+          value: backstage-egress
+      - equal:
+          path: spec.policyTypes
+          value:
+            - Egress
+      - contains:
+          path: spec.egress
+          content:
+            ports:
+              - port: 53
+                protocol: UDP
+              - port: 53
+                protocol: TCP
+      - contains:
+          path: spec.egress
+          content:
+            to:
+              - namespaceSelector: {}
+
+  - it: renders custom egress rules
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egressRules.customRules:
+        - to:
+            - ipBlock:
+                cidr: 10.0.0.0/8
+          ports:
+            - port: 443
+              protocol: TCP
+    asserts:
+      - contains:
+          path: spec.egress
+          content:
+            to:
+              - ipBlock:
+                  cidr: 10.0.0.0/8
+            ports:
+              - port: 443
+                protocol: TCP

--- a/charts/backstage/tests/networkpolicy_test.yaml
+++ b/charts/backstage/tests/networkpolicy_test.yaml
@@ -1,0 +1,64 @@
+suite: backstage ingress network policy
+templates:
+  - networkpolicy.yaml
+release:
+  name: backstage
+  namespace: backstage-system
+tests:
+  - it: does not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render without ingress rules
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders namespace and pod selector ingress rules
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.ingressRules.namespaceSelector:
+        kubernetes.io/metadata.name: ingress-system
+      networkPolicy.ingressRules.podSelector:
+        app.kubernetes.io/name: ingress-controller
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: spec.ingress[0]
+          value:
+            from:
+              - namespaceSelector:
+                  matchLabels:
+                    kubernetes.io/metadata.name: ingress-system
+              - podSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: ingress-controller
+            ports:
+              - port: 7007
+
+  - it: renders custom ingress rules
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.ingressRules.customRules:
+        - from:
+            - ipBlock:
+                cidr: 10.0.0.0/8
+          ports:
+            - port: 7007
+              protocol: TCP
+    asserts:
+      - contains:
+          path: spec.ingress
+          content:
+            from:
+              - ipBlock:
+                  cidr: 10.0.0.0/8
+            ports:
+              - port: 7007
+                protocol: TCP

--- a/charts/backstage/tests/pdb_test.yaml
+++ b/charts/backstage/tests/pdb_test.yaml
@@ -1,0 +1,58 @@
+suite: backstage pod disruption budget
+templates:
+  - pdb.yaml
+release:
+  name: backstage
+  namespace: backstage-system
+tests:
+  - it: does not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders with one unavailable pod by default when enabled
+    set:
+      backstage.pdb.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable
+
+  - it: renders minAvailable without maxUnavailable
+    set:
+      backstage.pdb.create: true
+      backstage.pdb.minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+      - notExists:
+          path: spec.maxUnavailable
+
+  - it: renders maxUnavailable without minAvailable
+    set:
+      backstage.pdb.create: true
+      backstage.pdb.maxUnavailable: 25%
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 25%
+      - notExists:
+          path: spec.minAvailable
+
+  - it: uses the same selector as the Deployment
+    set:
+      backstage.pdb.create: true
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: backstage
+            app.kubernetes.io/instance: backstage
+            app.kubernetes.io/component: backstage

--- a/charts/backstage/tests/service_test.yaml
+++ b/charts/backstage/tests/service_test.yaml
@@ -1,0 +1,96 @@
+suite: backstage service
+templates:
+  - service.yaml
+release:
+  name: backstage
+  namespace: backstage-system
+tests:
+  - it: renders a default ClusterIP Service with the backend port
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: backstage
+      - equal:
+          path: metadata.namespace
+          value: backstage-system
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].name
+          value: http-backend
+      - equal:
+          path: spec.ports[0].port
+          value: 7007
+      - equal:
+          path: spec.ports[0].targetPort
+          value: backend
+
+  - it: renders a NodePort Service with the configured node port
+    set:
+      service.type: NodePort
+      service.nodePorts.backend: 31007
+      service.externalTrafficPolicy: Local
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 31007
+      - equal:
+          path: spec.externalTrafficPolicy
+          value: Local
+
+  - it: renders the configured dual-stack IP families and policy
+    values:
+      - ../ci/service-dualstack-ip-family-values.yaml
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies
+          value:
+            - IPv4
+
+  - it: limits a LoadBalancer Service to the configured source ranges
+    set:
+      service.type: LoadBalancer
+      service.loadBalancerSourceRanges:
+        - 10.0.0.0/8
+        - 192.168.0.0/16
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - equal:
+          path: spec.loadBalancerSourceRanges
+          value:
+            - 10.0.0.0/8
+            - 192.168.0.0/16
+
+  - it: renders extra ports and annotations
+    set:
+      service.annotations:
+        example.com/owner: platform
+      service.extraPorts:
+        - name: metrics
+          port: 9464
+          targetPort: metrics
+          protocol: TCP
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform
+      - contains:
+          path: spec.ports
+          content:
+            name: metrics
+            port: 9464
+            targetPort: metrics
+            protocol: TCP

--- a/charts/backstage/tests/serviceaccount_test.yaml
+++ b/charts/backstage/tests/serviceaccount_test.yaml
@@ -1,0 +1,52 @@
+suite: backstage service account
+templates:
+  - serviceaccount.yaml
+release:
+  name: backstage
+  namespace: backstage-system
+tests:
+  - it: does not render when service account creation is disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: creates a ServiceAccount with the release name by default
+    set:
+      serviceAccount.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: backstage
+      - equal:
+          path: metadata.namespace
+          value: backstage-system
+      - equal:
+          path: automountServiceAccountToken
+          value: true
+
+  - it: gives an explicitly configured name precedence
+    set:
+      serviceAccount.create: true
+      serviceAccount.name: backstage-runtime
+    asserts:
+      - equal:
+          path: metadata.name
+          value: backstage-runtime
+
+  - it: renders annotations and disables token automounting
+    set:
+      serviceAccount.create: true
+      serviceAccount.annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/backstage
+      serviceAccount.automountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: arn:aws:iam::123456789012:role/backstage
+      - equal:
+          path: automountServiceAccountToken
+          value: false

--- a/charts/backstage/tests/validation_test.yaml
+++ b/charts/backstage/tests/validation_test.yaml
@@ -1,0 +1,32 @@
+suite: backstage value validation
+templates:
+  - backstage-deployment.yaml
+  - pdb.yaml
+  - service.yaml
+tests:
+  - it: rejects both PDB availability settings together
+    template: pdb.yaml
+    set:
+      backstage.pdb.create: true
+      backstage.pdb.minAvailable: 1
+      backstage.pdb.maxUnavailable: 1
+    asserts:
+      - failedTemplate:
+          errorMessage: backstage.pdb.minAvailable and backstage.pdb.maxUnavailable are mutually exclusive
+
+  - it: rejects an unsupported Service type
+    template: service.yaml
+    set:
+      service.type: Invalid
+    asserts:
+      - failedTemplate:
+          errorPattern: service.type.*must be one of
+
+  - it: rejects a provided PostgreSQL secret expression without a name
+    template: backstage-deployment.yaml
+    set:
+      postgresql.enabled: true
+      postgresql.auth.existingSecret: '{{ "" }}'
+    asserts:
+      - failedTemplate:
+          errorPattern: postgresql.auth.existingSecret must render to a non-empty secret name


### PR DESCRIPTION
## Description of the change

Completes the Backstage helm-unittest coverage described in #335. The suites now cover the Deployment, Service, ServiceAccount, Ingress, HTTPRoute, HPA, PDB, ingress and egress NetworkPolicies, ServiceMonitor, app-config ConfigMap, and extra deployment objects.

Cross-cutting tests verify naming precedence, rendered common metadata, and invalid value handling. The templates now also:

- reject simultaneous PDB `minAvailable` and `maxUnavailable` values
- reject a provided PostgreSQL secret expression that renders without a name
- propagate common labels and annotations to generated ConfigMaps and ServiceAccounts

## Existing or Associated Issue(s)

Addresses all scenarios in #335.

## Additional Information

Validated with:

- `helm unittest charts/backstage` (82 tests across 14 suites)
- `helm lint charts/backstage`
- `ct lint --config ct.yaml --target-branch main`
- `pre-commit run --all-files`

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to semver.
- [ ] Variables are documented in `values.yaml` and added to the README (not applicable: no value changes).
- [ ] JSON Schema generated (not applicable: no schema changes).
- [x] Chart lint and unit tests pass.